### PR TITLE
Fix error message casing

### DIFF
--- a/api/synthesize-thread.ts
+++ b/api/synthesize-thread.ts
@@ -56,7 +56,7 @@ const apiSynthesizeThreadHandler = async (req: any, res: any) => {
     });
   } catch (error) {
     console.error("Synthesis failed:", error);
-    return res.status(500).json({ error: "Internal server error" });
+    return res.status(500).json({ error: "Internal Server Error" });
   }
 };
 


### PR DESCRIPTION
## Summary
- fix inconsistent Internal Server Error message in synthesize-thread API

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format:check` *(fails: code style issues found in 23 files)*

------
https://chatgpt.com/codex/tasks/task_e_684fed5879b48329b6f45bd9e1e8e87f