### PR TITLE
Fix table names in search handlers

### DIFF
--- a/api/snapshots/search.ts
+++ b/api/snapshots/search.ts
@@ -8,7 +8,7 @@ const apiSnapshotsSearchHandler = async (req: any, res: any) => {
 
     const fieldMap = getFieldMap("Snapshots");
 
-    if (!airtableToken || !baseId || !TABLES.Snapshots) {
+    if (!airtableToken || !baseId || !TABLES.SNAPSHOTS) {
         return res.status(500).json({ error: "Missing Airtable configuration" });
     }
 
@@ -17,7 +17,7 @@ const apiSnapshotsSearchHandler = async (req: any, res: any) => {
         return res.status(400).json({ error: "Missing or invalid query parameter" });
     }
 
-    const url = `https://api.airtable.com/v0/${baseId}/${encodeURIComponent(TABLES.Snapshots)}`;
+    const url = `https://api.airtable.com/v0/${baseId}/${encodeURIComponent(TABLES.SNAPSHOTS)}`;
     const config = {
         headers: {
             Authorization: `Bearer ${airtableToken}`

--- a/api/threads/search.ts
+++ b/api/threads/search.ts
@@ -8,7 +8,7 @@ const threadsSearchHandler = async (req: any, res: any) => {
 
     const fieldMap = getFieldMap("Threads");
 
-    if (!airtableToken || !baseId || !TABLES.Threads) {
+    if (!airtableToken || !baseId || !TABLES.THREADS) {
         return res.status(500).json({ error: "Missing Airtable configuration" });
     }
 
@@ -17,7 +17,7 @@ const threadsSearchHandler = async (req: any, res: any) => {
         return res.status(400).json({ error: "Missing or invalid title parameter" });
     }
 
-    const url = `https://api.airtable.com/v0/${baseId}/${encodeURIComponent(TABLES.Threads)}`;
+    const url = `https://api.airtable.com/v0/${baseId}/${encodeURIComponent(TABLES.THREADS)}`;
     const config = {
         headers: {
             Authorization: `Bearer ${airtableToken}`


### PR DESCRIPTION
## Summary
- fix constants in snapshot and thread search endpoints

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684fee68639083298d83e1333deeb82c