### PR TITLE
Refactor GET handlers with inline field mapping

### DIFF
--- a/api/contacts/index.ts
+++ b/api/contacts/index.ts
@@ -18,9 +18,16 @@ const apiContactsHandler = async (req: any, res: any) => {
           fetchNextPage();
         });
 
-      const filteredRecords = records.map((record) => filterMappedFields(record, fieldMap));
+      const mappedRecords = records.map((record) => {
+        const mapped: Record<string, any> = { id: record.id };
+        for (const [internalKey, airtableField] of Object.entries(fieldMap)) {
+          mapped[internalKey] =
+            record.fields[airtableField] !== undefined ? record.fields[airtableField] : null;
+        }
+        return mapped;
+      });
 
-      return res.status(200).json(filteredRecords);
+      return res.status(200).json(mappedRecords);
     }
 
     if (req.method === "POST") {

--- a/api/log-entries/index.ts
+++ b/api/log-entries/index.ts
@@ -17,9 +17,16 @@ const apiLogEntriesHandler = async (req: any, res: any) => {
           fetchNextPage();
         });
 
-      const filteredRecords = records.map((record) => filterMappedFields(record, fieldMap));
+      const mappedRecords = records.map((record) => {
+        const mapped: Record<string, any> = { id: record.id };
+        for (const [internalKey, airtableField] of Object.entries(fieldMap)) {
+          mapped[internalKey] =
+            record.fields[airtableField] !== undefined ? record.fields[airtableField] : null;
+        }
+        return mapped;
+      });
 
-      return res.status(200).json(filteredRecords);
+      return res.status(200).json(mappedRecords);
     }
 
     if (req.method === "POST") {

--- a/api/snapshots/index.ts
+++ b/api/snapshots/index.ts
@@ -18,9 +18,16 @@ const apiSnapshotsHandler = async (req: any, res: any) => {
                     fetchNextPage();
                 });
 
-            const filteredRecords = records.map((record) => filterMappedFields(record, fieldMap));
+            const mappedRecords = records.map((record) => {
+                const mapped: Record<string, any> = { id: record.id };
+                for (const [internalKey, airtableField] of Object.entries(fieldMap)) {
+                    mapped[internalKey] =
+                        record.fields[airtableField] !== undefined ? record.fields[airtableField] : null;
+                }
+                return mapped;
+            });
 
-            return res.status(200).json(filteredRecords);
+            return res.status(200).json(mappedRecords);
         }
 
         if (req.method === "POST") {

--- a/api/threads/index.ts
+++ b/api/threads/index.ts
@@ -18,9 +18,16 @@ const apiThreadsHandler = async (req: any, res: any) => {
                     fetchNextPage();
                 });
 
-            const filteredRecords = records.map((record) => filterMappedFields(record, fieldMap));
+            const mappedRecords = records.map((record) => {
+                const mapped: Record<string, any> = { id: record.id };
+                for (const [internalKey, airtableField] of Object.entries(fieldMap)) {
+                    mapped[internalKey] =
+                        record.fields[airtableField] !== undefined ? record.fields[airtableField] : null;
+                }
+                return mapped;
+            });
 
-            return res.status(200).json(filteredRecords);
+            return res.status(200).json(mappedRecords);
         }
 
         if (req.method === "POST") {


### PR DESCRIPTION
## Summary
- map Airtable fields to internal keys directly in GET handlers
- keep POST logic unchanged

## Testing
- `npm test`
- `npm run lint` *(fails: 1527 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6850006feed08329b2a4ba935934c5c8