### PR TITLE
Add record field mapping utilities

### DIFF
--- a/__tests__/mapRecordFields.test.ts
+++ b/__tests__/mapRecordFields.test.ts
@@ -1,0 +1,17 @@
+const { mapInternalToAirtable, mapAirtableToInternal } = require('../lib/mapRecordFields');
+
+describe('mapInternalToAirtable', () => {
+  it('maps internal keys to Airtable field names', () => {
+    const fieldMap = { name: 'Name', age: 'Age' };
+    const input = { name: 'Tom', age: 30, extra: 'ignore' };
+    expect(mapInternalToAirtable(input, fieldMap)).toEqual({ Name: 'Tom', Age: 30 });
+  });
+});
+
+describe('mapAirtableToInternal', () => {
+  it('maps Airtable record fields to internal keys and includes id', () => {
+    const fieldMap = { name: 'Name', age: 'Age', missing: 'Missing' };
+    const record = { id: 'rec1', fields: { Name: 'Tom', Age: 30 } };
+    expect(mapAirtableToInternal(record, fieldMap)).toEqual({ id: 'rec1', name: 'Tom', age: 30, missing: null });
+  });
+});

--- a/lib/mapRecordFields.ts
+++ b/lib/mapRecordFields.ts
@@ -1,0 +1,22 @@
+function mapInternalToAirtable(input: Record<string, any>, fieldMap: Record<string, string>): Record<string, any> {
+  const mapped: Record<string, any> = {};
+  for (const key in input) {
+    const airtableField = fieldMap[key];
+    if (airtableField) {
+      mapped[airtableField] = input[key];
+    }
+  }
+  return mapped;
+}
+
+function mapAirtableToInternal(record: { id?: string; fields?: Record<string, any> }, fieldMap: Record<string, string>): Record<string, any> {
+  const result: Record<string, any> = { id: record.id };
+  for (const internalKey in fieldMap) {
+    const airtableField = fieldMap[internalKey];
+    const value = record.fields && record.fields[airtableField];
+    result[internalKey] = value !== undefined ? value : null;
+  }
+  return result;
+}
+
+module.exports = { mapInternalToAirtable, mapAirtableToInternal };


### PR DESCRIPTION
## Summary
- add `mapInternalToAirtable` and `mapAirtableToInternal` utilities
- provide Jest tests for these mapping functions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685005b3c2488329bedb81ae7eb027d3