### PR TITLE
Refactor log entry creation

### DIFF
--- a/api/log-entries/index.ts
+++ b/api/log-entries/index.ts
@@ -1,7 +1,8 @@
 const apiLogEntriesHandler = async (req: any, res: any) => {
   const getAirtableContext = require("../../lib/airtableBase");
   const { base, TABLES, airtableToken, baseId } = getAirtableContext();
-  const { getFieldMap, filterMappedFields } = require("../../lib/resolveFieldMap");
+  const { getFieldMap } = require("../../lib/resolveFieldMap");
+  const { mapInternalToAirtable } = require("../../lib/mapRecordFields");
 
   const tableName = TABLES.LOGS;
 
@@ -31,11 +32,11 @@ const apiLogEntriesHandler = async (req: any, res: any) => {
 
     if (req.method === "POST") {
       const fieldMap = getFieldMap(tableName);
-      const fields = req.body;
+      const airtableFields = mapInternalToAirtable(req.body, fieldMap);
 
-      const createdRecord = await base(tableName).create([{ fields: filterMappedFields({ fields }, fieldMap) }]);
+      const [createdRecord] = await base(tableName).create([{ fields: airtableFields }]);
 
-      return res.status(201).json(createdRecord);
+      return res.status(201).json({ id: createdRecord.id, ...req.body });
     }
 
     res.setHeader("Allow", ["GET", "POST"]);


### PR DESCRIPTION
## Summary
- refactor POST handler in `api/log-entries/index.ts` to use `mapInternalToAirtable`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68500b09e5b48329bbcd242ee9406ced