### PR TITLE
Refactor contacts POST handler

### DIFF
--- a/api/contacts/index.ts
+++ b/api/contacts/index.ts
@@ -2,7 +2,8 @@ const apiContactsHandler = async (req: any, res: any) => {
   const getAirtableContext = require("../../lib/airtableBase");
   const { base, TABLES, airtableToken, baseId } = getAirtableContext();
 
-  const { getFieldMap, filterMappedFields } = require("../../lib/resolveFieldMap");
+  const { getFieldMap } = require("../../lib/resolveFieldMap");
+  const { mapInternalToAirtable } = require("../../lib/mapRecordFields");
 
   const tableName = TABLES.CONTACTS;
 
@@ -32,11 +33,11 @@ const apiContactsHandler = async (req: any, res: any) => {
 
     if (req.method === "POST") {
       const fieldMap = getFieldMap(tableName);
-      const fields = req.body;
+      const airtableFields = mapInternalToAirtable(req.body, fieldMap);
 
-      const createdRecord = await base(tableName).create([{ fields: filterMappedFields({ fields }, fieldMap) }]);
+      const createdRecord = await base(tableName).create([{ fields: airtableFields }]);
 
-      return res.status(201).json(createdRecord);
+      return res.status(201).json({ id: createdRecord[0]?.id || createdRecord.id, ...req.body });
     }
 
     res.setHeader("Allow", ["GET", "POST"]);


### PR DESCRIPTION
## Summary
- map contacts POST handler fields to Airtable using helper

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_685007ea0b9883299fa95f471b83291b