### PR TITLE
Add Airtable field map generator

### DIFF
--- a/lib/resolveFieldMap.ts
+++ b/lib/resolveFieldMap.ts
@@ -1,3 +1,5 @@
+// This file is auto-generated. Run yarn generate:fieldmap to refresh.
+
 function getFieldMap(tableName: string): { [key: string]: string } {
   switch (tableName) {
     case "Contacts":
@@ -19,7 +21,7 @@ function getFieldMap(tableName: string): { [key: string]: string } {
         contacts: "Contacts (Linked)",
         threadId: "Thread ID"
       };
-    case "Snapshots":
+    case "Cold Snapshots":
       return {
         date: "Date",
         content: "Snapshot Markdown",
@@ -42,19 +44,4 @@ function getFieldMap(tableName: string): { [key: string]: string } {
   }
 }
 
-function filterMappedFields(fields: Record<string, any>, tableName: string): Record<string, any> {
-  const fieldMap = getFieldMap(tableName);
-  const mapped: Record<string, any> = {};
-  for (const internalKey in fieldMap) {
-    const airtableField = fieldMap[internalKey];
-    if (fields[airtableField] !== undefined) {
-      mapped[internalKey] = fields[airtableField];
-    }
-  }
-  return mapped;
-}
-
-module.exports = {
-  getFieldMap,
-  filterMappedFields
-};
+module.exports = { getFieldMap };

--- a/scripts/generateFieldMap.ts
+++ b/scripts/generateFieldMap.ts
@@ -1,0 +1,87 @@
+import fs from 'fs';
+import path from 'path';
+import fetch from 'node-fetch';
+
+const TABLES = ["Contacts", "Logs", "Cold Snapshots", "Threads"];
+
+function toCamelCase(str: string): string {
+  return str
+    .replace(/[^a-zA-Z0-9]+/g, ' ') // replace non-alphanumeric with space
+    .trim()
+    .split(/\s+/)
+    .map((word, index) => {
+      const lower = word.toLowerCase();
+      if (index === 0) return lower;
+      return lower.charAt(0).toUpperCase() + lower.slice(1);
+    })
+    .join('');
+}
+
+async function fetchFieldMap(table: string, token: string, baseId: string): Promise<Record<string, string> | null> {
+  const url = `https://api.airtable.com/v0/${baseId}/${encodeURIComponent(table)}?maxRecords=1`;
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to fetch table ${table}: ${res.status} ${res.statusText}`);
+  }
+  const data = (await res.json()) as any;
+  const record = data.records && data.records[0];
+  if (!record) {
+    console.warn(`Warning: No records found for table ${table}`);
+    return null;
+  }
+  const mapping: Record<string, string> = {};
+  for (const fieldName of Object.keys(record.fields)) {
+    const key = toCamelCase(fieldName);
+    mapping[key] = fieldName;
+  }
+  return mapping;
+}
+
+async function main() {
+  const token = process.env.AIRTABLE_TOKEN;
+  const baseId = process.env.AIRTABLE_BASE_ID;
+  if (!token || !baseId) {
+    throw new Error('Missing AIRTABLE_TOKEN or AIRTABLE_BASE_ID environment variables');
+  }
+  const allMaps: Record<string, Record<string, string>> = {};
+  for (const table of TABLES) {
+    const map = await fetchFieldMap(table, token, baseId);
+    if (map) {
+      allMaps[table] = map;
+    }
+  }
+
+  const lines: string[] = [];
+  lines.push('// This file is auto-generated. Run yarn generate:fieldmap to refresh.');
+  lines.push('');
+  lines.push('function getFieldMap(tableName: string): { [key: string]: string } {');
+  lines.push('  switch (tableName) {');
+
+  for (const [table, mapping] of Object.entries(allMaps)) {
+    lines.push(`    case ${JSON.stringify(table)}:`);
+    lines.push('      return {');
+    for (const [key, field] of Object.entries(mapping)) {
+      lines.push(`        ${key}: ${JSON.stringify(field)},`);
+    }
+    lines.push('      };');
+  }
+
+  lines.push('    default:');
+  lines.push('      return {};');
+  lines.push('  }');
+  lines.push('}');
+  lines.push('');
+  lines.push('module.exports = { getFieldMap };');
+
+  const outputPath = path.join(__dirname, '../lib/resolveFieldMap.ts');
+  fs.writeFileSync(outputPath, lines.join('\n'));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a TypeScript script to generate field mappings from Airtable
- update `lib/resolveFieldMap.ts` to be auto‑generated and export only `getFieldMap`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68501e41f7dc8329bb4f3c6fbf84ab8b