### PR TITLE
Ensure array schema items

### DIFF
--- a/schemas/contacts.schema.json
+++ b/schemas/contacts.schema.json
@@ -112,7 +112,8 @@
       }
     },
     "importedTable": {
-      "type": "array"
+      "type": "array",
+      "items": { "type": "string" }
     },
     "followupNeeded": {
       "type": "boolean"
@@ -125,7 +126,8 @@
       "type": "string"
     },
     "latestRelatedLog": {
-      "type": "array"
+      "type": "array",
+      "items": { "type": "string" }
     },
     "id": {
       "type": "string"
@@ -138,7 +140,8 @@
       "type": "string"
     },
     "threads": {
-      "type": "array"
+      "type": "array",
+      "items": { "type": "string" }
     },
     "created": {
       "type": "string",

--- a/schemas/logs.schema.json
+++ b/schemas/logs.schema.json
@@ -7,7 +7,8 @@
       "type": "string"
     },
     "contactsLinked": {
-      "type": "array"
+      "type": "array",
+      "items": { "type": "string" }
     },
     "linkedContactId": {
       "type": "string"
@@ -55,10 +56,12 @@
       "format": "date-time"
     },
     "contacts": {
-      "type": "array"
+      "type": "array",
+      "items": { "type": "string" }
     },
     "threadLinked": {
-      "type": "array"
+      "type": "array",
+      "items": { "type": "string" }
     },
     "threadId": {
       "type": "string"

--- a/schemas/threads.schema.json
+++ b/schemas/threads.schema.json
@@ -33,13 +33,15 @@
       "type": "string"
     },
     "associatedContacts": {
-      "type": "array"
+      "type": "array",
+      "items": { "type": "string" }
     },
     "contactId": {
       "type": "string"
     },
     "associatedLogs": {
-      "type": "array"
+      "type": "array",
+      "items": { "type": "string" }
     },
     "logId": {
       "type": "string"

--- a/scripts/generateFieldMap.ts
+++ b/scripts/generateFieldMap.ts
@@ -63,6 +63,9 @@ function fieldToSchema(field: any): Record<string, any> {
     default:
       schema.type = 'string';
   }
+  if (schema.type === 'array' && !schema.items) {
+    schema.items = { type: 'string' };
+  }
   return schema;
 }
 


### PR DESCRIPTION
## Summary
- default `items: {type: "string"}` for Airtable array fields
- regenerate schema snippets so all arrays have `items` defined

## Testing
- `npm test`
- `npm run lint` *(fails: many linter errors)*


------
https://chatgpt.com/codex/tasks/task_e_68512b6f85f0832982e25f5bf8b774ce