### PR TITLE
Fix Airtable context initialization per request

### DIFF
--- a/api/contacts/search.ts
+++ b/api/contacts/search.ts
@@ -1,10 +1,16 @@
 const getAirtableContext = require("../../lib/airtableBase");
 const { createSearchHandler } = require("../../lib/airtableSearch");
 
-const { TABLES } = getAirtableContext();
+const apiContactsSearchHandler = async (req: any, res: any) => {
+  const { TABLES } = getAirtableContext();
 
-module.exports = createSearchHandler({
-  tableName: TABLES.CONTACTS,
-  fieldName: "Name",
-  queryParam: "name",
-});
+  const handler = createSearchHandler({
+    tableName: TABLES.CONTACTS,
+    fieldName: "Name",
+    queryParam: "name",
+  });
+
+  return handler(req, res);
+};
+
+module.exports = apiContactsSearchHandler;

--- a/api/log-entries/search.ts
+++ b/api/log-entries/search.ts
@@ -2,10 +2,10 @@ const { airtableSearch } = require("../../lib/airtableSearch");
 const getAirtableContext = require("../../lib/airtableBase");
 const { getFieldMap } = require("../../lib/resolveFieldMap");
 
-const { TABLES } = getAirtableContext();
 const fieldMap = getFieldMap("Logs");
 
 const apiLogEntriesSearchHandler = async (req: any, res: any) => {
+  const { TABLES } = getAirtableContext();
   const { name, threadId } = req.query;
 
   if (!name && !threadId) {

--- a/api/snapshots/search.ts
+++ b/api/snapshots/search.ts
@@ -2,11 +2,17 @@ const getAirtableContext = require("../../lib/airtableBase");
 const { createSearchHandler } = require("../../lib/airtableSearch");
 const { getFieldMap } = require("../../lib/resolveFieldMap");
 
-const { TABLES } = getAirtableContext();
-const fieldMap = getFieldMap(TABLES.SNAPSHOTS);
+const apiSnapshotsSearchHandler = async (req: any, res: any) => {
+  const { TABLES } = getAirtableContext();
+  const fieldMap = getFieldMap(TABLES.SNAPSHOTS);
 
-module.exports = createSearchHandler({
-  tableName: TABLES.SNAPSHOTS,
-  fieldName: fieldMap.keyUpdates || "Key Updates",
-  queryParam: "query",
-});
+  const handler = createSearchHandler({
+    tableName: TABLES.SNAPSHOTS,
+    fieldName: fieldMap.keyUpdates || "Key Updates",
+    queryParam: "query",
+  });
+
+  return handler(req, res);
+};
+
+module.exports = apiSnapshotsSearchHandler;

--- a/api/threads/search.ts
+++ b/api/threads/search.ts
@@ -1,10 +1,16 @@
 const getAirtableContext = require("../../lib/airtableBase");
 const { createSearchHandler } = require("../../lib/airtableSearch");
 
-const { TABLES } = getAirtableContext();
+const apiThreadsSearchHandler = async (req: any, res: any) => {
+  const { TABLES } = getAirtableContext();
 
-module.exports = createSearchHandler({
-  tableName: TABLES.THREADS,
-  fieldName: "Name",
-  queryParam: "title",
-});
+  const handler = createSearchHandler({
+    tableName: TABLES.THREADS,
+    fieldName: "Name",
+    queryParam: "title",
+  });
+
+  return handler(req, res);
+};
+
+module.exports = apiThreadsSearchHandler;


### PR DESCRIPTION
## Summary
- update all search handlers so `getAirtableContext()` is invoked during each request

## Testing
- `npm run lint` *(fails: 1601 errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68514dc81eac8329bc5c7e4423c7e295