### PR TITLE
Add debug logging for Airtable search requests

### DIFF
--- a/lib/airtableSearch.ts
+++ b/lib/airtableSearch.ts
@@ -8,7 +8,16 @@ async function airtableSearch(tableName: string, filterFormula: string) {
     throw new Error("Missing Airtable configuration");
   }
 
+  if (process.env.NODE_ENV !== "production") {
+    console.log("[airtableSearch] baseId:", baseId, "tableName:", tableName);
+    console.log("[airtableSearch] filterFormula:", filterFormula);
+  }
+
   const url = `https://api.airtable.com/v0/${baseId}/${encodeURIComponent(tableName)}`;
+
+  if (process.env.NODE_ENV !== "production") {
+    console.log("[airtableSearch] url:", url);
+  }
   const config = {
     headers: { Authorization: `Bearer ${airtableToken}` },
     params: { filterByFormula: filterFormula, maxRecords: 10 }


### PR DESCRIPTION
## Summary
- add `[airtableSearch]` debug logs for resolved base/table, filter formula and request URL
- logs only trigger outside production

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6851591442308329a4eb16df3cbeb776