### PR TITLE
Fix log initialization to avoid runtime error

### DIFF
--- a/api/contacts/[id].ts
+++ b/api/contacts/[id].ts
@@ -1,11 +1,10 @@
-console.log("[contacts/[id]] TABLES.CONTACTS =", TABLES.CONTACTS, "| id =", id);
-
 const idContactsHandler = async (req: any, res: any) => {
   const axios = require("axios");
   const getAirtableContext = require("../../lib/airtableBase");
   const { base, TABLES, airtableToken, baseId } = getAirtableContext();
 
   const { id } = req.query;
+  console.log("[contacts/[id]] TABLES.CONTACTS =", TABLES.CONTACTS, "| id =", id);
   if (!id) {
     return res.status(400).json({ error: "Missing contact ID" });
   }


### PR DESCRIPTION
## Summary
- move debug log after TABLES and id declarations in contacts handler

## Testing
- `npm test`
- `npm run lint` *(fails: 1603 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685161c96d38832992751083c9f9742f