### PR TITLE
Update vercel routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,18 @@
 {
   "version": 2,
   "routes": [
-    {
-      "src": "/api/(.*)",
-      "dest": "/dist/api/$1.js"
-    }
+    { "src": "/api/contacts/search", "dest": "/dist/api/contacts/search/index.js" },
+    { "src": "/api/contacts/(?:[^/]+)", "dest": "/dist/api/contacts/[id].js" },
+    { "src": "/api/log-entries/search", "dest": "/dist/api/log-entries/search/index.js" },
+    { "src": "/api/log-entries/(?:[^/]+)", "dest": "/dist/api/log-entries/[id].js" },
+    { "src": "/api/snapshots/search", "dest": "/dist/api/snapshots/search/index.js" },
+    { "src": "/api/snapshots/(?:[^/]+)", "dest": "/dist/api/snapshots/[id].js" },
+    { "src": "/api/threads/search", "dest": "/dist/api/threads/search/index.js" },
+    { "src": "/api/threads/(?:[^/]+)", "dest": "/dist/api/threads/[id].js" },
+    { "src": "/api/snapshots/latest", "dest": "/dist/api/snapshots/latest.js" },
+    { "src": "/api/snapshots/synthesize-current-state", "dest": "/dist/api/snapshots/synthesize-current-state.js" },
+    { "src": "/api/synthesize-thread", "dest": "/dist/api/synthesize-thread.js" },
+    { "src": "/api/(.*)", "dest": "/dist/api/$1.js" }
   ]
 }
+


### PR DESCRIPTION
## Summary
- add explicit vercel routes for search and id endpoints
- map snapshot utility endpoints to built files

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68516ed6031c83298521993dd7e26d6a