### PR TITLE
Refactor search route files

### DIFF
--- a/api/contacts/search.ts
+++ b/api/contacts/search.ts
@@ -1,6 +1,6 @@
 // Moved to prevent route collision with [id].ts in Next.js
-const getAirtableContext = require("../../../lib/airtableBase");
-const { createSearchHandler } = require("../../../lib/airtableSearch");
+const getAirtableContext = require("../../lib/airtableBase");
+const { createSearchHandler } = require("../../lib/airtableSearch");
 
 const apiContactsSearchHandler = async (req: any, res: any) => {
   const { TABLES } = getAirtableContext();

--- a/api/log-entries/search.ts
+++ b/api/log-entries/search.ts
@@ -1,7 +1,7 @@
 // Moved to prevent route collision with [id].ts in Next.js
-const { airtableSearch } = require("../../../lib/airtableSearch");
-const getAirtableContext = require("../../../lib/airtableBase");
-const { getFieldMap } = require("../../../lib/resolveFieldMap");
+const { airtableSearch } = require("../../lib/airtableSearch");
+const getAirtableContext = require("../../lib/airtableBase");
+const { getFieldMap } = require("../../lib/resolveFieldMap");
 
 const fieldMap = getFieldMap("Logs");
 

--- a/api/snapshots/search.ts
+++ b/api/snapshots/search.ts
@@ -1,7 +1,7 @@
 // Moved to prevent route collision with [id].ts in Next.js
-const getAirtableContext = require("../../../lib/airtableBase");
-const { createSearchHandler } = require("../../../lib/airtableSearch");
-const { getFieldMap } = require("../../../lib/resolveFieldMap");
+const getAirtableContext = require("../../lib/airtableBase");
+const { createSearchHandler } = require("../../lib/airtableSearch");
+const { getFieldMap } = require("../../lib/resolveFieldMap");
 
 const apiSnapshotsSearchHandler = async (req: any, res: any) => {
   const { TABLES } = getAirtableContext();

--- a/api/threads/search.ts
+++ b/api/threads/search.ts
@@ -1,6 +1,6 @@
 // Moved to prevent route collision with [id].ts in Next.js
-const getAirtableContext = require("../../../lib/airtableBase");
-const { createSearchHandler } = require("../../../lib/airtableSearch");
+const getAirtableContext = require("../../lib/airtableBase");
+const { createSearchHandler } = require("../../lib/airtableSearch");
 
 const apiThreadsSearchHandler = async (req: any, res: any) => {
   const { TABLES } = getAirtableContext();

--- a/vercel.json
+++ b/vercel.json
@@ -1,13 +1,13 @@
 {
   "version": 2,
   "routes": [
-    { "src": "/api/contacts/search", "dest": "/dist/api/contacts/search/index.js" },
+    { "src": "/api/contacts/search", "dest": "/dist/api/contacts/search.js" },
     { "src": "/api/contacts/(?:[^/]+)", "dest": "/dist/api/contacts/[id].js" },
-    { "src": "/api/log-entries/search", "dest": "/dist/api/log-entries/search/index.js" },
+    { "src": "/api/log-entries/search", "dest": "/dist/api/log-entries/search.js" },
     { "src": "/api/log-entries/(?:[^/]+)", "dest": "/dist/api/log-entries/[id].js" },
-    { "src": "/api/snapshots/search", "dest": "/dist/api/snapshots/search/index.js" },
+    { "src": "/api/snapshots/search", "dest": "/dist/api/snapshots/search.js" },
     { "src": "/api/snapshots/(?:[^/]+)", "dest": "/dist/api/snapshots/[id].js" },
-    { "src": "/api/threads/search", "dest": "/dist/api/threads/search/index.js" },
+    { "src": "/api/threads/search", "dest": "/dist/api/threads/search.js" },
     { "src": "/api/threads/(?:[^/]+)", "dest": "/dist/api/threads/[id].js" },
     { "src": "/api/snapshots/latest", "dest": "/dist/api/snapshots/latest.js" },
     { "src": "/api/snapshots/synthesize-current-state", "dest": "/dist/api/snapshots/synthesize-current-state.js" },


### PR DESCRIPTION
## Summary
- move `/search` endpoints up one level to avoid Next.js route conflicts
- update relative imports in new search endpoint files
- adjust vercel config for new build paths

## Testing
- `npm test`
- `npm run lint` *(fails: 1608 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685177da01548329abc24260c8fc26eb