### PR TITLE
Fix TypeScript issues in API handlers

### DIFF
--- a/api/snapshots/index.ts
+++ b/api/snapshots/index.ts
@@ -21,9 +21,10 @@ const apiSnapshotsHandler = async (req: any, res: any) => {
 
             const mappedRecords = records.map((record) => {
                 const mapped: Record<string, any> = { id: record.id };
+                const fields = record.fields as Record<string, any>;
                 for (const [internalKey, airtableField] of Object.entries(fieldMap)) {
-                    mapped[internalKey] =
-                        record.fields[airtableField] !== undefined ? record.fields[airtableField] : null;
+                    const key = airtableField as keyof typeof fields;
+                    mapped[internalKey] = fields[key] !== undefined ? fields[key] : null;
                 }
                 return mapped;
             });

--- a/api/snapshots/search.ts
+++ b/api/snapshots/search.ts
@@ -1,9 +1,9 @@
 // Moved to prevent route collision with [id].ts in Next.js
-const getAirtableContext = require("../../lib/airtableBase");
-const { createSearchHandler } = require("../../lib/airtableSearch");
-const { getFieldMap } = require("../../lib/resolveFieldMap");
-
 const apiSnapshotsSearchHandler = async (req: any, res: any) => {
+  const getAirtableContext = require("../../lib/airtableBase");
+  const { createSearchHandler } = require("../../lib/airtableSearch");
+  const { getFieldMap } = require("../../lib/resolveFieldMap");
+
   const { TABLES } = getAirtableContext();
   const fieldMap = getFieldMap(TABLES.SNAPSHOTS);
 

--- a/api/threads/index.ts
+++ b/api/threads/index.ts
@@ -20,9 +20,10 @@ const apiThreadsHandler = async (req: any, res: any) => {
 
             const mappedRecords = records.map((record) => {
                 const mapped: Record<string, any> = { id: record.id };
+                const fields = record.fields as Record<string, any>;
                 for (const [internalKey, airtableField] of Object.entries(fieldMap)) {
-                    mapped[internalKey] =
-                        record.fields[airtableField] !== undefined ? record.fields[airtableField] : null;
+                    const key = airtableField as keyof typeof fields;
+                    mapped[internalKey] = fields[key] !== undefined ? fields[key] : null;
                 }
                 return mapped;
             });

--- a/api/threads/search.ts
+++ b/api/threads/search.ts
@@ -1,8 +1,8 @@
 // Moved to prevent route collision with [id].ts in Next.js
-const getAirtableContext = require("../../lib/airtableBase");
-const { createSearchHandler } = require("../../lib/airtableSearch");
-
 const apiThreadsSearchHandler = async (req: any, res: any) => {
+  const getAirtableContext = require("../../lib/airtableBase");
+  const { createSearchHandler } = require("../../lib/airtableSearch");
+
   const { TABLES } = getAirtableContext();
 
   const handler = createSearchHandler({


### PR DESCRIPTION
## Summary
- make Airtable field mapping safe in snapshot handler
- make Airtable field mapping safe in threads handler
- avoid global `require` declarations in snapshot search endpoint
- avoid global `require` declarations in thread search endpoint

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685184fb8338832985abe6da3f463ae8