### PR TITLE
Fix TS2451 errors from global variable redeclarations

### DIFF
--- a/api/contacts/search.ts
+++ b/api/contacts/search.ts
@@ -1,4 +1,5 @@
 // Moved to prevent route collision with [id].ts in Next.js
+export {};
 const getAirtableContext = require("../../lib/airtableBase");
 const { createSearchHandler } = require("../../lib/airtableSearch");
 

--- a/api/log-entries/search.ts
+++ b/api/log-entries/search.ts
@@ -1,4 +1,5 @@
 // Moved to prevent route collision with [id].ts in Next.js
+export {};
 const { airtableSearch } = require("../../lib/airtableSearch");
 const getAirtableContext = require("../../lib/airtableBase");
 const { getFieldMap } = require("../../lib/resolveFieldMap");

--- a/api/snapshots/search.ts
+++ b/api/snapshots/search.ts
@@ -1,4 +1,5 @@
 // Moved to prevent route collision with [id].ts in Next.js
+export {};
 const apiSnapshotsSearchHandler = async (req: any, res: any) => {
   const getAirtableContext = require("../../lib/airtableBase");
   const { createSearchHandler } = require("../../lib/airtableSearch");

--- a/api/threads/search.ts
+++ b/api/threads/search.ts
@@ -1,4 +1,5 @@
 // Moved to prevent route collision with [id].ts in Next.js
+export {};
 const apiThreadsSearchHandler = async (req: any, res: any) => {
   const getAirtableContext = require("../../lib/airtableBase");
   const { createSearchHandler } = require("../../lib/airtableSearch");

--- a/lib/airtableBase.ts
+++ b/lib/airtableBase.ts
@@ -1,3 +1,4 @@
+export {};
 const Airtable = require("airtable");
 
 const getAirtableContext = () => {

--- a/lib/airtableSearch.ts
+++ b/lib/airtableSearch.ts
@@ -1,3 +1,4 @@
+export {};
 const axios = require("axios");
 const getAirtableContext = require("./airtableBase");
 

--- a/lib/mapRecordFields.ts
+++ b/lib/mapRecordFields.ts
@@ -1,3 +1,4 @@
+export {};
 function mapInternalToAirtable(input: Record<string, any>, fieldMap: Record<string, string>): Record<string, any> {
   const mapped: Record<string, any> = {};
   for (const key in input) {


### PR DESCRIPTION
## Summary
- mark various API search utilities as modules to avoid global scope collisions
- mark Airtable helpers as modules

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851947776b483298d39aef15dcee25e