### PR TITLE
Fix Airtable records typing

### DIFF
--- a/api/contacts/index.ts
+++ b/api/contacts/index.ts
@@ -11,12 +11,15 @@ const apiContactsHandler = async (req: any, res: any) => {
 
   try {
     if (req.method === "GET") {
-      const records: any[] = [];
+      const records: AirtableRecord<FieldSet>[] = [];
       const fieldMap = getFieldMap(tableName);
 
       await base(tableName)
         .select({ view: "Grid view" })
-        .eachPage((recordsPage: Records<FieldSet>, fetchNextPage: () => void) => {
+        .eachPage((
+          recordsPage: readonly AirtableRecord<FieldSet>[],
+          fetchNextPage: () => void
+        ) => {
           records.push(...recordsPage);
           fetchNextPage();
         });

--- a/api/log-entries/index.ts
+++ b/api/log-entries/index.ts
@@ -11,15 +11,20 @@ const apiLogEntriesHandler = async (req: any, res: any) => {
 
   try {
     if (req.method === "GET") {
-      const records: any[] = [];
+      const records: AirtableRecord<FieldSet>[] = [];
       const fieldMap = getFieldMap(tableName);
 
       await base(tableName)
         .select({ view: "Grid view" })
-        .eachPage((recordsPage: Records<FieldSet>, fetchNextPage: () => void) => {
-          records.push(...recordsPage);
-          fetchNextPage();
-        });
+        .eachPage(
+          (
+            recordsPage: readonly AirtableRecord<FieldSet>[],
+            fetchNextPage: () => void
+          ) => {
+            records.push(...recordsPage);
+            fetchNextPage();
+          }
+        );
 
       const mappedRecords = records.map((record) => {
         const mapped: Record<string, any> = { id: record.id };

--- a/api/snapshots/index.ts
+++ b/api/snapshots/index.ts
@@ -11,15 +11,20 @@ const apiSnapshotsHandler = async (req: any, res: any) => {
 
     try {
         if (req.method === "GET") {
-            const records: any[] = [];
+            const records: AirtableRecord<FieldSet>[] = [];
             const fieldMap = getFieldMap(tableName);
 
             await base(tableName)
                 .select({ view: "Grid view" })
-                .eachPage((recordsPage: Records<FieldSet>, fetchNextPage: () => void) => {
-                    records.push(...recordsPage);
-                    fetchNextPage();
-                });
+                .eachPage(
+                    (
+                        recordsPage: readonly AirtableRecord<FieldSet>[],
+                        fetchNextPage: () => void
+                    ) => {
+                        records.push(...recordsPage);
+                        fetchNextPage();
+                    }
+                );
 
             const mappedRecords = records.map((record) => {
                 const mapped: Record<string, any> = { id: record.id };

--- a/api/threads/index.ts
+++ b/api/threads/index.ts
@@ -10,15 +10,20 @@ const apiThreadsHandler = async (req: any, res: any) => {
 
     try {
         if (req.method === "GET") {
-            const records: any[] = [];
+            const records: AirtableRecord<FieldSet>[] = [];
             const fieldMap = getFieldMap(tableName);
 
             await base(tableName)
                 .select({ view: "Grid view" })
-                .eachPage((recordsPage: Records<FieldSet>, fetchNextPage: () => void) => {
-                    records.push(...recordsPage);
-                    fetchNextPage();
-                });
+                .eachPage(
+                    (
+                        recordsPage: readonly AirtableRecord<FieldSet>[],
+                        fetchNextPage: () => void
+                    ) => {
+                        records.push(...recordsPage);
+                        fetchNextPage();
+                    }
+                );
 
             const mappedRecords = records.map((record) => {
                 const mapped: Record<string, any> = { id: record.id };


### PR DESCRIPTION
## Summary
- use readonly `AirtableRecord<FieldSet>[]` when iterating Airtable pages
- properly type `records` arrays in API handlers

## Testing
- `npx tsc`
- `npm test` *(fails: ReferenceError: module is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6852ca22b0708329be5d03cb35753dfb