### PR TITLE
Enable ts-jest ESM support

### DIFF
--- a/__tests__/mapRecordFields.test.ts
+++ b/__tests__/mapRecordFields.test.ts
@@ -1,4 +1,4 @@
-const { mapInternalToAirtable, mapAirtableToInternal } = require('../lib/mapRecordFields');
+import { mapInternalToAirtable, mapAirtableToInternal } from '../lib/mapRecordFields.js';
 
 describe('mapInternalToAirtable', () => {
   it('maps internal keys to Airtable field names', () => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,14 @@
-module.exports = {
-  preset: 'ts-jest',
+export default {
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  globals: {
+    'ts-jest': {
+      useESM: true,
+    }
+  },
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
   testMatch: ['**/?(*.)+(spec|test).ts']
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@eslint/js": "^9.28.0",
         "@types/airtable": "^0.10.0",
-        "@types/jest": "^29.5.14",
+        "@types/jest": "^29.5.11",
         "@types/node": "^20.4.1",
         "@typescript-eslint/eslint-plugin": "^8.34.0",
         "@typescript-eslint/parser": "^8.34.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "^9.28.0",
     "@types/airtable": "^0.10.0",
-    "@types/jest": "^29.5.14",
+    "@types/jest": "^29.5.11",
     "@types/node": "^20.4.1",
     "@typescript-eslint/eslint-plugin": "^8.34.0",
     "@typescript-eslint/parser": "^8.34.0",


### PR DESCRIPTION
## Summary
- configure Jest for ESM and TypeScript
- update `@types/jest` version
- modernize test to use ESM imports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852ce3aba708329a3a7cc342656d99b