### PR TITLE
Update tsup config for esm output

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -4,12 +4,13 @@ import { join } from 'path'
 export default defineConfig({
   entry: ['api/**/*.ts', 'lib/**/*.ts', 'utils/**/*.ts'],
   outDir: 'dist',
-  format: ['cjs'],
+  format: ['esm'],
   target: 'node18',
   dts: false,
   splitting: false,
   sourcemap: true,
   clean: true,
+  minify: false,
   shims: false,
   esbuildOptions(options) {
     options.external = options.external || []


### PR DESCRIPTION
## Summary
- bundle for Node18 using ESM modules
- disable minification to aid debugging

## Testing
- `npm test`
- `npm run lint` *(fails: 1561 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6852d11360dc8329a38b1942ced69bf2