### PR TITLE
Adjust tsup output and scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "license": "MIT",
   "scripts": {
+    "prebuild": "rm -f api/**/*.js api/**/*.js.map",
     "build": "tsup",
     "dev": "tsup --watch",
     "lint": "eslint . --ext .ts,.js",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -3,15 +3,15 @@ import { join } from 'path'
 
 export default defineConfig({
   entry: ['api/**/*.ts', 'lib/**/*.ts', 'utils/**/*.ts'],
-  outDir: 'dist',
+  outDir: 'api',
   format: ['esm'],
   target: 'node18',
   dts: false,
   splitting: false,
   sourcemap: true,
-  clean: true,
+  clean: false,
   minify: false,
-  shims: false,
+  shims: true,
   esbuildOptions(options) {
     options.external = options.external || []
     options.external.push('openai') // Safely mark as external

--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,4 @@
 {
   "version": 2,
-  "framework": null,
-  "functions": {
-    "dist/api/**/*.js": {
-      "maxDuration": 30,
-      "memory": 512
-    }
-  }
+  "framework": null
 }


### PR DESCRIPTION
## Summary
- build JS directly into `/api`
- cleanup compiled JS before builds
- simplify Vercel config

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, no-unused-vars, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6852fe067e5c8329a58f6814f7f6ad57