### PR TITLE
Adjust build output directory for Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,14 +10,15 @@
   "license": "MIT",
   "scripts": {
     "prebuild": "rm -f api/**/*.js api/**/*.js.map",
-    "build": "tsup",
+    "build": "npm run clean && tsup",
     "dev": "tsup --watch",
     "lint": "eslint . --ext .ts,.js",
     "lint:fix": "eslint . --ext .ts,.js --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "generate:fieldmap": "ts-node scripts/generateFieldMap.ts",
-    "test": "jest"
+    "test": "jest",
+    "clean": "rm -rf dist"
   },
   "dependencies": {
     "axios": "^1.6.0",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -3,13 +3,13 @@ import { join } from "path";
 
 export default defineConfig({
     entry: ["api/**/*.ts", "lib/**/*.ts", "utils/**/*.ts"],
-    outDir: ".",
+    outDir: "dist",
     format: ["esm"],
     target: "node20",
     dts: false,
     splitting: false,
     sourcemap: true,
-    clean: false,
+    clean: true,
     minify: false,
     shims: true,
     noExternal: ['uri-js', 'tr46', 'punycode'],

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,8 @@
 {
-  "version": 2,
-  "framework": null
+  "functions": {
+    "dist/api/**/*.js": {
+      "maxDuration": 30,
+      "memory": 512
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- output tsup build artifacts to `dist/`
- adjust npm scripts for cleaning and building
- configure Vercel functions to use `dist`

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68531f5d7f3083299eae0d61b090e244