### PR TITLE
Update build scripts and vercelignore

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,2 +1,2 @@
-# Ignore compiled output only
+# ignore sourcemaps
 api/**/*.js.map

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "license": "MIT",
   "scripts": {
     "prebuild": "find api -name '*.js' -delete -o -name '*.js.map' -delete",
-  "build": "npm run prebuild && tsup",
+    "build": "tsup && find api -name '*.ts' -delete",
+    "vercel-build": "npm run build",
     "dev": "tsup --watch",
     "lint": "eslint . --ext .ts,.js",
     "lint:fix": "eslint . --ext .ts,.js --fix",


### PR DESCRIPTION
## Summary
- tweak build scripts for API
- update `.vercelignore`

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*
- `npm run lint` *(fails: many eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6853c9cda0e48329912b4b763f3c3d44