### PR TITLE
Migrate to Vercel Build Output v3

### DIFF
--- a/__tests__/mapRecordFields.test.ts
+++ b/__tests__/mapRecordFields.test.ts
@@ -1,4 +1,4 @@
-import { mapInternalToAirtable, mapAirtableToInternal } from '../lib/mapRecordFields.js';
+import { mapInternalToAirtable, mapAirtableToInternal } from '../src/lib/mapRecordFields.ts';
 
 describe('mapInternalToAirtable', () => {
   it('maps internal keys to Airtable field names', () => {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "license": "MIT",
   "scripts": {
-    "prebuild": "rm -rf api",
-    "build": "tsup",
+    "prebuild": "rm -rf .vercel/output/functions api",
+    "build": "tsup && node scripts/prepareFuncs.mjs",
     "vercel-build": "npm run build",
     "dev": "tsup --watch",
     "lint": "eslint . --ext .ts,.js",
@@ -22,7 +22,8 @@
   },
   "dependencies": {
     "axios": "^1.6.0",
-    "dotenv": "^16.5.0"
+    "dotenv": "^16.5.0",
+    "fast-glob": "^3.3.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.28.0",
@@ -42,7 +43,8 @@
     "ts-node": "^10.9.2",
     "tsup": "^8.5.0",
     "typescript": "^5.8.3",
-    "typescript-eslint": "^8.34.0"
+    "typescript-eslint": "^8.34.0",
+    "fast-glob": "^3.3.2"
   },
   "engines": {
     "node": "20.x"

--- a/scripts/prepareFuncs.mjs
+++ b/scripts/prepareFuncs.mjs
@@ -1,0 +1,24 @@
+import { promises as fs } from 'fs';
+import { join, dirname } from 'path';
+import glob from 'fast-glob';
+
+async function run() {
+  const files = await glob('.vercel/output/functions/api/**/*.js', {
+    ignore: ['**/*.map']
+  });
+
+  for (const file of files) {
+    const funcDir = file.replace(/\.js$/, '.func');
+    await fs.mkdir(funcDir, { recursive: true });
+    await fs.rename(file, join(funcDir, 'index.js'));
+    await fs.writeFile(
+      join(funcDir, '.vc-config.json'),
+      JSON.stringify({ runtime: 'nodejs20.x' })
+    );
+  }
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,24 +1,13 @@
 import { defineConfig } from "tsup";
-import { join } from "path";
 
 export default defineConfig({
-    entry: ['src/api/**/*.ts', 'src/lib/**/*.ts', 'src/utils/**/*.ts'],
-    outDir: "api",
-    format: ["esm"],
-    target: "node20",
-    dts: false,
-    splitting: false,
-    sourcemap: true,
-    clean: true,
-    minify: false,
-    shims: false,
-    noExternal: ['uri-js', 'tr46', 'punycode'],
-    esbuildOptions(options) {
-        options.external = options.external || [];
-        options.external.push("openai"); // Safely mark as external
-        options.outbase = 'src/api';
-    },
-    alias: {
-        "@": join(__dirname, "./")
-    }
+  entry: ['src/api/**/*.ts'],
+  outDir: '.vercel/output/functions',
+  clean: true,
+  format: ['esm'],
+  target: 'node20',
+  shims: false,
+  esbuildOptions(opts) {
+    opts.outbase = 'src'; // keep the 'api/' segment in output paths
+  },
 });

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,4 @@
 {
   "version": 2,
-  "framework": null,
-  "outputDirectory": "api"
+  "framework": null
 }


### PR DESCRIPTION
## Summary
- bundle API endpoints into `.vercel/output/functions`
- generate `.func` directories with Node 20 runtime config
- update build scripts for Vercel build output v3
- simplify `vercel.json`
- fix test path for `mapRecordFields`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685450b44f288329bd6259b7e32e527f