### PR TITLE
Finalize Build-Output v3 on Node 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "license": "MIT",
   "scripts": {
-    "prebuild": "rm -rf api/*.js api/**/*.js api/**/*.js.map",
-    "build": "tsup",
+    "prebuild": "rm -rf .vercel/output/functions",
+    "build": "tsup && node scripts/prepareFuncs.mjs",
     "vercel-build": "npm run build",
     "dev": "tsup --watch",
     "lint": "eslint . --ext .ts,.js",
@@ -36,6 +36,7 @@
     "eslint": "^9.28.0",
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-prettier": "^5.4.1",
+    "fast-glob": "^3.3.2",
     "globals": "^16.2.0",
     "jest": "^29.7.0",
     "prettier": "^3.5.3",

--- a/scripts/prepareFuncs.mjs
+++ b/scripts/prepareFuncs.mjs
@@ -1,0 +1,29 @@
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import glob from 'fast-glob';
+
+async function run() {
+  const files = await glob('.vercel/output/functions/api/**/*.js', {
+    ignore: ['**/*.map']
+  });
+
+  for (const file of files) {
+    const funcDir = file.replace(/\.js$/, '.func');
+    await fs.mkdir(funcDir, { recursive: true });
+    await fs.rename(file, join(funcDir, 'index.js'));
+    await fs.writeFile(
+      join(funcDir, '.vc-config.json'),
+      JSON.stringify({ runtime: 'nodejs20.x' })
+    );
+  }
+
+  // Build-Output manifest
+  await fs.mkdir('.vercel/output', { recursive: true });
+  await fs.writeFile(
+    '.vercel/output/config.json',
+    JSON.stringify({ version: 3 })
+  );
+}
+
+run().catch(err => { console.error(err); process.exit(1); });
+

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -2,12 +2,10 @@ import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ['src/api/**/*.ts'],
-  outDir: 'api',
+  outDir: '.vercel/output/functions',
   clean: true,
   format: ['esm'],
   target: 'node20',
+  outbase: 'src',
   shims: false,
-  esbuildOptions(opts) {
-    opts.outbase = 'src/api';
-  },
-});
+  });

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,4 @@
 {
   "version": 2,
-  "functions": {
-    "api/**/*.js": { "runtime": "nodejs20.x" }
-  }
+  "framework": null
 }


### PR DESCRIPTION
## Summary
- emit serverless functions to `.vercel/output/functions`
- prepare functions in Build Output v3 format
- keep output folder on prebuild and update scripts
- set minimal Vercel config
- include dev dependency for `fast-glob`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68545ebf10788329a41ff9eaa2ae1d13