### PR TITLE
fix(v3): add handler and cjs output

### DIFF
--- a/scripts/prepareFuncs.mjs
+++ b/scripts/prepareFuncs.mjs
@@ -13,7 +13,7 @@ async function run() {
     await fs.rename(file, join(funcDir, 'index.js'));
     await fs.writeFile(
       join(funcDir, '.vc-config.json'),
-      JSON.stringify({ runtime: 'nodejs20.x' })
+      JSON.stringify({ runtime: 'nodejs20.x', handler: 'index.js' })
     );
   }
 

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   entry: ['src/api/**/*.ts'],
   outDir: '.vercel/output/functions',
   clean: true,
-  format: ['esm'],
+  format: ['cjs'],
   target: 'node20',
   outbase: 'src',
   shims: false,


### PR DESCRIPTION
## Summary
- add `handler` key to `.vc-config.json`
- output CJS format from tsup for Node 20 compatibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685462530fc48329bae331d0861b9f61