### PR TITLE
Fix Build Output v3 handlers

### DIFF
--- a/scripts/prepareFuncs.mjs
+++ b/scripts/prepareFuncs.mjs
@@ -2,13 +2,13 @@ import { promises as fs } from 'fs';
 import { join } from 'path';
 import glob from 'fast-glob';
 
-async function run() {
-  const files = await glob('/vercel/output/functions/**/*.{js,cjs}', { … });
+async function main() {
+  const files = await glob('/vercel/output/functions/**/*.{js,cjs}', {
     ignore: ['**/*.map']
   });
 
   for (const file of files) {
-    const funcDir = file.replace(/\.js$/, '.func');
+    const funcDir = file.replace(/\.(c?js)$/, '.func');
     await fs.mkdir(funcDir, { recursive: true });
     await fs.rename(file, join(funcDir, 'index.js'));
     await fs.writeFile(
@@ -17,13 +17,11 @@ async function run() {
     );
   }
 
-  // Build-Output manifest
-  await fs.mkdir('.vercel/output', { recursive: true });
-  await fs.writeFile(
-    '.vercel/output/config.json',
-    JSON.stringify({ version: 3 })
-  );
+  await fs.mkdir('/vercel/output', { recursive: true });
+  await fs.writeFile('/vercel/output/config.json', JSON.stringify({ version: 3 }));
 }
 
-run().catch(err => { console.error(err); process.exit(1); });
-
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- move v3 handlers into `*.func` folders and write `.vc-config.json`
- ensure tsup outputs CommonJS to `/vercel/output/functions`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68546499eec483298d979e18c5bbed81