### PR TITLE
Convert health endpoint to Node runtime

### DIFF
--- a/api/health.ts
+++ b/api/health.ts
@@ -1,10 +1,10 @@
 // api/health.ts     ← exact filename
 
-export const runtime = 'edge';          // tell Vercel this is an Edge Function
+// Standard Node.js API route
+const apiHealthHandler = async (req: any, res: any) => {
+  return res
+    .status(200)
+    .json({ status: "ok", timestamp: new Date().toISOString() });
+};
 
-export default function health() {
-  return new Response(
-    JSON.stringify({ status: 'ok', timestamp: new Date().toISOString() }),
-    { status: 200, headers: { 'content-type': 'application/json' } }
-  );
-}
+export default apiHealthHandler;


### PR DESCRIPTION
## Summary
- rewrite `/api/health.ts` to run as a standard Node.js function instead of an Edge function

## Testing
- `npm test`
- `npm run lint` *(fails: many TypeScript lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68553804f8bc8329a238168762490014