### PR TITLE
Remove extensions from internal imports

### DIFF
--- a/__tests__/mapRecordFields.test.ts
+++ b/__tests__/mapRecordFields.test.ts
@@ -1,4 +1,4 @@
-import { mapInternalToAirtable, mapAirtableToInternal } from '../lib/mapRecordFields.ts';
+import { mapInternalToAirtable, mapAirtableToInternal } from '../lib/mapRecordFields';
 
 describe('mapInternalToAirtable', () => {
   it('maps internal keys to Airtable field names', () => {

--- a/api/contacts/[id].ts
+++ b/api/contacts/[id].ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import getAirtableContext from "../../lib/airtableBase.js";
+import getAirtableContext from "../../lib/airtableBase";
 
 const idContactsHandler = async (req: any, res: any) => {
   const { base, TABLES, airtableToken, baseId } = getAirtableContext();

--- a/api/contacts/index.ts
+++ b/api/contacts/index.ts
@@ -1,6 +1,6 @@
-import getAirtableContext from "../../lib/airtableBase.js";
-import { getFieldMap } from "../../lib/resolveFieldMap.js";
-import { mapInternalToAirtable } from "../../lib/mapRecordFields.js";
+import getAirtableContext from "../../lib/airtableBase";
+import { getFieldMap } from "../../lib/resolveFieldMap";
+import { mapInternalToAirtable } from "../../lib/mapRecordFields";
 import { FieldSet, Record as AirtableRecord } from "airtable";
 
 const apiContactsHandler = async (req: any, res: any) => {

--- a/api/contacts/search.ts
+++ b/api/contacts/search.ts
@@ -1,6 +1,6 @@
 // Moved to prevent route collision with [id].ts in Next.js
-import getAirtableContext from "../../lib/airtableBase.js";
-import { createSearchHandler } from "../../lib/airtableSearch.js";
+import getAirtableContext from "../../lib/airtableBase";
+import { createSearchHandler } from "../../lib/airtableSearch";
 
 const apiContactsSearchHandler = async (req: any, res: any) => {
   const { TABLES } = getAirtableContext();

--- a/api/log-entries/[id].ts
+++ b/api/log-entries/[id].ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import getAirtableContext from "../../lib/airtableBase.js";
+import getAirtableContext from "../../lib/airtableBase";
 
 const idLogEntryHandler = async (req: any, res: any) => {
   const { base, TABLES, airtableToken, baseId } = getAirtableContext();

--- a/api/log-entries/index.ts
+++ b/api/log-entries/index.ts
@@ -1,6 +1,6 @@
-import getAirtableContext from "../../lib/airtableBase.js";
-import { getFieldMap } from "../../lib/resolveFieldMap.js";
-import { mapInternalToAirtable } from "../../lib/mapRecordFields.js";
+import getAirtableContext from "../../lib/airtableBase";
+import { getFieldMap } from "../../lib/resolveFieldMap";
+import { mapInternalToAirtable } from "../../lib/mapRecordFields";
 import { FieldSet, Record as AirtableRecord } from "airtable";
 
 

--- a/api/log-entries/search.ts
+++ b/api/log-entries/search.ts
@@ -1,7 +1,7 @@
 // Moved to prevent route collision with [id].ts in Next.js
-import { airtableSearch } from "../../lib/airtableSearch.js";
-import getAirtableContext from "../../lib/airtableBase.js";
-import { getFieldMap } from "../../lib/resolveFieldMap.js";
+import { airtableSearch } from "../../lib/airtableSearch";
+import getAirtableContext from "../../lib/airtableBase";
+import { getFieldMap } from "../../lib/resolveFieldMap";
 
 const fieldMap = getFieldMap("Logs");
 

--- a/api/snapshots/[id].ts
+++ b/api/snapshots/[id].ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import getAirtableContext from "../../lib/airtableBase.js";
+import getAirtableContext from "../../lib/airtableBase";
 
 const idSnapshotsHandler = async (req: any, res: any) => {
     const { base, TABLES, airtableToken, baseId } = getAirtableContext();

--- a/api/snapshots/index.ts
+++ b/api/snapshots/index.ts
@@ -1,6 +1,6 @@
-import getAirtableContext from "../../lib/airtableBase.js";
-import { getFieldMap } from "../../lib/resolveFieldMap.js";
-import { mapInternalToAirtable } from "../../lib/mapRecordFields.js";
+import getAirtableContext from "../../lib/airtableBase";
+import { getFieldMap } from "../../lib/resolveFieldMap";
+import { mapInternalToAirtable } from "../../lib/mapRecordFields";
 import { FieldSet, Record as AirtableRecord } from "airtable";
 
 

--- a/api/snapshots/latest.ts
+++ b/api/snapshots/latest.ts
@@ -1,4 +1,4 @@
-import getAirtableContext from "../../lib/airtableBase.js";
+import getAirtableContext from "../../lib/airtableBase";
 
 const apiSnapshotsLatestHandler = async (req: any, res: any) => {
     const { base, TABLES, airtableToken, baseId } = getAirtableContext();

--- a/api/snapshots/search.ts
+++ b/api/snapshots/search.ts
@@ -1,7 +1,7 @@
 // Moved to prevent route collision with [id].ts in Next.js
-import getAirtableContext from "../../lib/airtableBase.js";
-import { createSearchHandler } from "../../lib/airtableSearch.js";
-import { getFieldMap } from "../../lib/resolveFieldMap.js";
+import getAirtableContext from "../../lib/airtableBase";
+import { createSearchHandler } from "../../lib/airtableSearch";
+import { getFieldMap } from "../../lib/resolveFieldMap";
 
 const apiSnapshotsSearchHandler = async (req: any, res: any) => {
 

--- a/api/snapshots/synthesize-current-state.ts
+++ b/api/snapshots/synthesize-current-state.ts
@@ -1,5 +1,5 @@
-import getAirtableContext from "../../lib/airtableBase.js";
-import { getFieldMap, filterMappedFields } from "../../lib/resolveFieldMap.js";
+import getAirtableContext from "../../lib/airtableBase";
+import { getFieldMap, filterMappedFields } from "../../lib/resolveFieldMap";
 
 const apiSnapshotsSynthesizeHandler = async (req: any, res: any) => {
   const { base, TABLES, airtableToken, baseId } = getAirtableContext();

--- a/api/synthesize-thread.ts
+++ b/api/synthesize-thread.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
-import getAirtableContext from "../lib/airtableBase.js";
-import { getFieldMap } from "../lib/resolveFieldMap.js";
-import { synthesizeThreadNarrative } from "../lib/synthesisUtils.js";
+import getAirtableContext from "../lib/airtableBase";
+import { getFieldMap } from "../lib/resolveFieldMap";
+import { synthesizeThreadNarrative } from "../lib/synthesisUtils";
 
 
 const apiSynthesizeThreadHandler = async (req: any, res: any) => {

--- a/api/threads/[id].ts
+++ b/api/threads/[id].ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import getAirtableContext from "../../lib/airtableBase.js";
+import getAirtableContext from "../../lib/airtableBase";
 
 const idThreadsHandler = async (req: any, res: any) => {
     const { base, TABLES, airtableToken, baseId } = getAirtableContext();

--- a/api/threads/index.ts
+++ b/api/threads/index.ts
@@ -1,5 +1,5 @@
-import getAirtableContext from "../../lib/airtableBase.js";
-import { getFieldMap, filterMappedFields } from "../../lib/resolveFieldMap.js";
+import getAirtableContext from "../../lib/airtableBase";
+import { getFieldMap, filterMappedFields } from "../../lib/resolveFieldMap";
 import { FieldSet, Record as AirtableRecord } from "airtable";
 
 

--- a/api/threads/search.ts
+++ b/api/threads/search.ts
@@ -1,6 +1,6 @@
 // Moved to prevent route collision with [id].ts in Next.js
-import getAirtableContext from "../../lib/airtableBase.js";
-import { createSearchHandler } from "../../lib/airtableSearch.js";
+import getAirtableContext from "../../lib/airtableBase";
+import { createSearchHandler } from "../../lib/airtableSearch";
 
 const apiThreadsSearchHandler = async (req: any, res: any) => {
 

--- a/lib/airtableSearch.ts
+++ b/lib/airtableSearch.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import getAirtableContext from "./airtableBase.js";
+import getAirtableContext from "./airtableBase";
 
 async function airtableSearch(tableName: string, filterFormula: string) {
   const { airtableToken, baseId } = getAirtableContext();

--- a/lib/synthesisUtils.ts
+++ b/lib/synthesisUtils.ts
@@ -1,5 +1,5 @@
-import getAirtableContext from "../lib/airtableBase.js";
-import { getFieldMap } from "../lib/resolveFieldMap.js";
+import getAirtableContext from "../lib/airtableBase";
+import { getFieldMap } from "../lib/resolveFieldMap";
 import { FieldSet, Record as AirtableRecord } from "airtable";
 import OpenAI from "openai";
 

--- a/utils/getLookupValue.ts
+++ b/utils/getLookupValue.ts
@@ -1,5 +1,5 @@
-import getAirtableContext from "../lib/airtableBase.js";
-import { getFieldMap } from "../lib/resolveFieldMap.js";
+import getAirtableContext from "../lib/airtableBase";
+import { getFieldMap } from "../lib/resolveFieldMap";
 
 export function getLookupValue(tableName: string, fieldKey: string, record: Record<string, any>): string | null {
     const { base, TABLES, airtableToken, baseId } = getAirtableContext();


### PR DESCRIPTION
## Summary
- drop `.js`/`.ts` file extensions from local import paths

## Testing
- `npm test` *(fails: Jest configuration issue)*
- `npm run lint` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685558773bb4832996080dfe11b51e23