### PR TITLE
Dynamic search with schema-driven filters

### DIFF
--- a/api/airtableSearch.ts
+++ b/api/airtableSearch.ts
@@ -1,6 +1,16 @@
 import getAirtableContext from "./airtable_base.js";
 
-async function airtableSearch(tableName: string, filterFormula: string) {
+interface SearchOptions {
+  maxRecords?: number;
+  sortField?: string;
+  sortDirection?: "asc" | "desc";
+}
+
+async function airtableSearch(
+  tableName: string,
+  filterFormula: string,
+  options: SearchOptions = {}
+) {
   const { airtableToken, baseId } = getAirtableContext();
 
   if (!airtableToken || !baseId) {
@@ -18,11 +28,17 @@ async function airtableSearch(tableName: string, filterFormula: string) {
     headers: { Authorization: `Bearer ${airtableToken}` }
   };
 
-  const params = new URLSearchParams({
-    filterByFormula: filterFormula,
-    maxRecords: "10"
-  }).toString();
-  const fullUrl = url + "?" + params;
+  const params = new URLSearchParams();
+  if (filterFormula) params.set("filterByFormula", filterFormula);
+  params.set("maxRecords", String(options.maxRecords ?? 10));
+  if (options.sortField) {
+    params.append("sort[0][field]", options.sortField);
+    params.append(
+      "sort[0][direction]",
+      options.sortDirection ?? "asc"
+    );
+  }
+  const fullUrl = url + "?" + params.toString();
 
   const response = await fetch(fullUrl, config);
   if (!response.ok) {

--- a/api/buildAirtableFormula.ts
+++ b/api/buildAirtableFormula.ts
@@ -1,0 +1,71 @@
+export interface FormulaOptions {
+  /** if present, search across all string fields */
+  q?: string | string[];
+  /** map of query params excluding reserved ones */
+  params: Record<string, string | string[]>;
+  /** additional filters */
+  updatedAfter?: string;
+  createdAfter?: string;
+  recent?: string;
+}
+
+export function buildAirtableFormula(
+  options: FormulaOptions,
+  fieldMap: Record<string, string>
+): string {
+  const conds: string[] = [];
+  const { q, params, updatedAfter, createdAfter, recent } = options;
+
+  const getValue = (v: string | string[] | undefined): string | undefined => {
+    if (!v) return undefined;
+    return Array.isArray(v) ? v[0] : v;
+  };
+
+  const escape = (val: string) => val.replace(/"/g, '\\"');
+
+  const qVal = getValue(q);
+  if (qVal) {
+    const esc = escape(qVal);
+    const subs = Object.values(fieldMap).map(
+      (f) => `FIND(LOWER("${esc}"), LOWER({${f}}))`
+    );
+    if (subs.length) conds.push(`OR(${subs.join(', ')})`);
+  }
+
+  for (const [key, value] of Object.entries(params)) {
+    const val = getValue(value);
+    if (!val) continue;
+    const field = fieldMap[key];
+    if (!field) continue;
+    const esc = escape(val);
+    conds.push(`FIND(LOWER("${esc}"), LOWER({${field}}))`);
+  }
+
+  const dateFieldForUpdated =
+    fieldMap.lastModified ||
+    fieldMap.updatedAt ||
+    fieldMap.updated ||
+    fieldMap.lastModifiedTime;
+  const dateFieldForCreated =
+    fieldMap.created || fieldMap.createdDate || fieldMap.createdAt;
+
+  const addDateFilter = (field: string | undefined, date: string) => {
+    if (!field) return;
+    conds.push(`IS_AFTER({${field}}, \"${date}\")`);
+  };
+
+  const upd = getValue(updatedAfter);
+  if (upd) addDateFilter(dateFieldForUpdated, new Date(upd).toISOString());
+  const crt = getValue(createdAfter);
+  if (crt) addDateFilter(dateFieldForCreated, new Date(crt).toISOString());
+  const rec = getValue(recent);
+  if (rec && !isNaN(parseInt(rec))) {
+    const days = parseInt(rec);
+    const date = new Date(Date.now() - days * 86400000).toISOString();
+    addDateFilter(dateFieldForUpdated || dateFieldForCreated, date);
+  }
+
+  if (conds.length === 0) return '';
+  if (conds.length === 1) return conds[0];
+  return `AND(${conds.join(', ')})`;
+}

--- a/api/contacts-search.ts
+++ b/api/contacts-search.ts
@@ -1,51 +1,6 @@
-// Moved to prevent route collision with [id].ts in Next.js
 import getAirtableContext from "./airtable_base.js";
-import { airtableSearch } from "./airtableSearch.js";
-import { getFieldMap } from "./resolveFieldMap.js";
+import { createDynamicSearchHandler } from "./dynamicSearchHandler.js";
 
-const apiContactsSearchHandler = async (req: any, res: any) => {
-  const { TABLES } = getAirtableContext();
-  const tableName = TABLES.CONTACTS;
+const { TABLES } = getAirtableContext();
 
-  if (req.method !== "GET") {
-    res.setHeader("Allow", ["GET"]);
-    return res.status(405).end(`Method ${req.method} Not Allowed`);
-  }
-
-  const { name } = req.query;
-  if (!name || typeof name !== "string") {
-    return res.status(400).json({ error: "Missing or invalid name parameter" });
-  }
-
-  const escaped = name.replace(/"/g, '\\"');
-  const formula = `FIND(LOWER("${escaped}"), LOWER({Name}))`;
-
-  try {
-    const records = await airtableSearch(tableName, formula);
-    if (!records || records.length === 0) {
-      return res.status(404).json({ message: "No matching record found" });
-    }
-
-    const fieldMap = getFieldMap(tableName);
-    const mappedRecords = records.map((record) => {
-      const mapped: Record<string, any> = { id: record.id };
-      const fields = record.fields as Record<string, any>;
-      for (const [internalKey, airtableField] of Object.entries(fieldMap)) {
-        const key = airtableField as keyof typeof fields;
-        mapped[internalKey] = fields[key] !== undefined ? fields[key] : null;
-      }
-      return mapped;
-    });
-
-    return res.status(200).json(mappedRecords);
-  } catch (error: any) {
-    console.error("API error:", {
-      message: error.message,
-      config: error.config,
-      response: error.response?.data,
-    });
-    return res.status(500).json({ error: "Internal Server Error" });
-  }
-};
-
-export default apiContactsSearchHandler;
+export default createDynamicSearchHandler(TABLES.CONTACTS);

--- a/api/dynamicSearchHandler.ts
+++ b/api/dynamicSearchHandler.ts
@@ -1,0 +1,61 @@
+import { getFieldMap } from "./resolveFieldMap.js";
+import { airtableSearch } from "./airtableSearch.js";
+import { buildAirtableFormula } from "./buildAirtableFormula.js";
+
+export function createDynamicSearchHandler(tableName: string) {
+  return async function (req: any, res: any) {
+    const { method, query } = req;
+    if (method !== "GET") {
+      res.setHeader("Allow", ["GET"]);
+      return res.status(405).end(`Method ${method} Not Allowed`);
+    }
+
+    const fieldMap = getFieldMap(tableName);
+    const { limit, sortBy, sortOrder, q, updatedAfter, createdAfter, recent, ...rest } = query as Record<string, any>;
+
+    const formula = buildAirtableFormula(
+      { q, params: rest, updatedAfter, createdAfter, recent },
+      fieldMap
+    );
+
+    const options: any = {};
+    if (limit) {
+      const n = parseInt(Array.isArray(limit) ? limit[0] : limit);
+      if (!isNaN(n)) options.maxRecords = n;
+    }
+    if (sortBy && typeof sortBy === "string") {
+      const field = fieldMap[sortBy];
+      if (field) {
+        options.sortField = field;
+        options.sortDirection =
+          typeof sortOrder === "string" && sortOrder.toLowerCase() === "desc" ? "desc" : "asc";
+      }
+    }
+
+    try {
+      const records = await airtableSearch(tableName, formula, options);
+      if (!records || records.length === 0) {
+        return res.status(404).json({ message: "No matching record found" });
+      }
+
+      const mappedRecords = records.map((record: any) => {
+        const mapped: Record<string, any> = { id: record.id };
+        const fields = record.fields as Record<string, any>;
+        for (const [internalKey, airtableField] of Object.entries(fieldMap)) {
+          const key = airtableField as keyof typeof fields;
+          mapped[internalKey] = fields[key] !== undefined ? fields[key] : null;
+        }
+        return mapped;
+      });
+
+      return res.status(200).json(mappedRecords);
+    } catch (error: any) {
+      console.error("API error:", {
+        message: error.message,
+        config: error.config,
+        response: error.response?.data,
+      });
+      return res.status(500).json({ error: "Internal Server Error" });
+    }
+  };
+}

--- a/api/log-entries-search.ts
+++ b/api/log-entries-search.ts
@@ -1,65 +1,6 @@
-// Moved to prevent route collision with [id].ts in Next.js
-import { airtableSearch } from "./airtableSearch.js";
 import getAirtableContext from "./airtable_base.js";
-import { getFieldMap } from "./resolveFieldMap.js";
+import { createDynamicSearchHandler } from "./dynamicSearchHandler.js";
 
-const apiLogEntriesSearchHandler = async (req: any, res: any) => {
-  const { TABLES } = getAirtableContext();
-  const tableName = TABLES.LOGS;
-  const fieldMap = getFieldMap(tableName);
+const { TABLES } = getAirtableContext();
 
-  if (req.method !== "GET") {
-    res.setHeader("Allow", ["GET"]);
-    return res.status(405).end(`Method ${req.method} Not Allowed`);
-  }
-
-  const { name, threadId } = req.query;
-
-  if (!name && !threadId) {
-    return res
-      .status(400)
-      .json({ error: "Missing search parameter (name or threadId)" });
-  }
-
-  let formula: string;
-  if (name) {
-    if (typeof name !== "string") {
-      return res.status(400).json({ error: "Missing or invalid name parameter" });
-    }
-    const escaped = name.replace(/"/g, '\\"');
-    formula = `FIND(LOWER("${escaped}"), LOWER({${fieldMap.summary}}))`;
-  } else {
-    if (typeof threadId !== "string") {
-      return res.status(400).json({ error: "Invalid threadId parameter" });
-    }
-    formula = `{${fieldMap.threadId}} = "${threadId}"`;
-  }
-
-  try {
-    const records = await airtableSearch(tableName, formula);
-    if (!records || records.length === 0) {
-      return res.status(404).json({ message: "No matching log entry found" });
-    }
-
-    const mappedRecords = records.map((record) => {
-      const mapped: Record<string, any> = { id: record.id };
-      const fields = record.fields as Record<string, any>;
-      for (const [internalKey, airtableField] of Object.entries(fieldMap)) {
-        const key = airtableField as keyof typeof fields;
-        mapped[internalKey] = fields[key] !== undefined ? fields[key] : null;
-      }
-      return mapped;
-    });
-
-    return res.status(200).json(mappedRecords);
-  } catch (error: any) {
-    console.error("API error:", {
-      message: error.message,
-      config: error.config,
-      response: error.response?.data,
-    });
-    return res.status(500).json({ error: "Internal Server Error" });
-  }
-};
-
-export default apiLogEntriesSearchHandler;
+export default createDynamicSearchHandler(TABLES.LOGS);

--- a/api/snapshots-search.ts
+++ b/api/snapshots-search.ts
@@ -1,52 +1,6 @@
-// Moved to prevent route collision with [id].ts in Next.js
 import getAirtableContext from "./airtable_base.js";
-import { airtableSearch } from "./airtableSearch.js";
-import { getFieldMap } from "./resolveFieldMap.js";
+import { createDynamicSearchHandler } from "./dynamicSearchHandler.js";
 
-const apiSnapshotsSearchHandler = async (req: any, res: any) => {
-  const { TABLES } = getAirtableContext();
-  const tableName = TABLES.SNAPSHOTS;
+const { TABLES } = getAirtableContext();
 
-  if (req.method !== "GET") {
-    res.setHeader("Allow", ["GET"]);
-    return res.status(405).end(`Method ${req.method} Not Allowed`);
-  }
-
-  const { query } = req.query;
-  if (!query || typeof query !== "string") {
-    return res.status(400).json({ error: "Missing or invalid query parameter" });
-  }
-
-  const fieldMap = getFieldMap(tableName);
-  const searchField = fieldMap.keyUpdates || "Key Updates";
-  const escaped = query.replace(/"/g, '\\"');
-  const formula = `FIND(LOWER("${escaped}"), LOWER({${searchField}}))`;
-
-  try {
-    const records = await airtableSearch(tableName, formula);
-    if (!records || records.length === 0) {
-      return res.status(404).json({ message: "No matching record found" });
-    }
-
-    const mappedRecords = records.map((record) => {
-      const mapped: Record<string, any> = { id: record.id };
-      const fields = record.fields as Record<string, any>;
-      for (const [internalKey, airtableField] of Object.entries(fieldMap)) {
-        const key = airtableField as keyof typeof fields;
-        mapped[internalKey] = fields[key] !== undefined ? fields[key] : null;
-      }
-      return mapped;
-    });
-
-    return res.status(200).json(mappedRecords);
-  } catch (error: any) {
-    console.error("API error:", {
-      message: error.message,
-      config: error.config,
-      response: error.response?.data,
-    });
-    return res.status(500).json({ error: "Internal Server Error" });
-  }
-};
-
-export default apiSnapshotsSearchHandler;
+export default createDynamicSearchHandler(TABLES.SNAPSHOTS);

--- a/api/threads-search.ts
+++ b/api/threads-search.ts
@@ -1,51 +1,6 @@
-// Moved to prevent route collision with [id].ts in Next.js
 import getAirtableContext from "./airtable_base.js";
-import { airtableSearch } from "./airtableSearch.js";
-import { getFieldMap } from "./resolveFieldMap.js";
+import { createDynamicSearchHandler } from "./dynamicSearchHandler.js";
 
-const apiThreadsSearchHandler = async (req: any, res: any) => {
-  const { TABLES } = getAirtableContext();
-  const tableName = TABLES.THREADS;
+const { TABLES } = getAirtableContext();
 
-  if (req.method !== "GET") {
-    res.setHeader("Allow", ["GET"]);
-    return res.status(405).end(`Method ${req.method} Not Allowed`);
-  }
-
-  const { title } = req.query;
-  if (!title || typeof title !== "string") {
-    return res.status(400).json({ error: "Missing or invalid title parameter" });
-  }
-
-  const escaped = title.replace(/"/g, '\\"');
-  const formula = `FIND(LOWER("${escaped}"), LOWER({Name}))`;
-
-  try {
-    const records = await airtableSearch(tableName, formula);
-    if (!records || records.length === 0) {
-      return res.status(404).json({ message: "No matching record found" });
-    }
-
-    const fieldMap = getFieldMap(tableName);
-    const mappedRecords = records.map((record) => {
-      const mapped: Record<string, any> = { id: record.id };
-      const fields = record.fields as Record<string, any>;
-      for (const [internalKey, airtableField] of Object.entries(fieldMap)) {
-        const key = airtableField as keyof typeof fields;
-        mapped[internalKey] = fields[key] !== undefined ? fields[key] : null;
-      }
-      return mapped;
-    });
-
-    return res.status(200).json(mappedRecords);
-  } catch (error: any) {
-    console.error("API error:", {
-      message: error.message,
-      config: error.config,
-      response: error.response?.data,
-    });
-    return res.status(500).json({ error: "Internal Server Error" });
-  }
-};
-
-export default apiThreadsSearchHandler;
+export default createDynamicSearchHandler(TABLES.THREADS);


### PR DESCRIPTION
## Summary
- add reusable formula builder and dynamic search handler
- allow specifying limit, sorting and date filters
- update all search routes to use the dynamic handler
- enhance `airtableSearch` with optional sort and limit params

## Testing
- `npm test` *(fails: Jest unable to parse ES module imports)*

------
https://chatgpt.com/codex/tasks/task_e_68580cc2ebb48329b627dd695a1e7c26