### PR TITLE
Improve fuzzy search field selection

### DIFF
--- a/api/buildAirtableFormula.ts
+++ b/api/buildAirtableFormula.ts
@@ -59,7 +59,12 @@ export function buildAirtableFormula(
 
     if (val.trim() === "") continue;
     const esc = escape(val);
-    conds.push(`FIND(LOWER("${esc}"), LOWER({${field}}))`);
+
+    if (searchableFields.includes(key)) {
+      conds.push(`FIND(LOWER("${esc}"), LOWER({${field}}))`);
+    } else {
+      conds.push(`LOWER({${field}}) = LOWER("${esc}")`);
+    }
   }
 
   const dateFieldForUpdated =

--- a/api/tableSchemas.ts
+++ b/api/tableSchemas.ts
@@ -35,16 +35,13 @@ function getSearchableTextFields(tableName: string): string[] {
   const props = schema.properties || {};
   const result: string[] = [];
   for (const [key, val] of Object.entries(props)) {
-    const t = (val as any).type;
-    if (t === "string") {
-      result.push(key);
-    } else if (
-      t === "array" &&
-      (val as any).items &&
-      (val as any).items.type === "string"
-    ) {
-      result.push(key);
-    }
+    const v = val as any;
+    if (v.type !== "string") continue;
+    if (v.readOnly) continue;
+    if (v.format === "date-time") continue;
+    const name = key.toLowerCase();
+    if (name === "id" || name.endsWith("id") || name.includes("date")) continue;
+    result.push(key);
   }
   return result;
 }


### PR DESCRIPTION
## Summary
- refine getSearchableTextFields to exclude IDs and date fields
- match query params with fuzzy search only for searchable string fields

## Testing
- `npm run lint`
- `npm test` *(fails: Jest couldn't run due to ESM configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68583346c2d48329b6d44081ab56d164