### PR TITLE
Fix JSON import syntax

### DIFF
--- a/api/tableSchemas.ts
+++ b/api/tableSchemas.ts
@@ -1,7 +1,7 @@
-import contacts from "../schemas/contacts.schema.json" assert { type: "json" };
-import logs from "../schemas/logs.schema.json" assert { type: "json" };
-import coldSnapshots from "../schemas/coldSnapshots.schema.json" assert { type: "json" };
-import threads from "../schemas/threads.schema.json" assert { type: "json" };
+import contacts from "../schemas/contacts.schema.json" with { type: "json" };
+import logs from "../schemas/logs.schema.json" with { type: "json" };
+import coldSnapshots from "../schemas/coldSnapshots.schema.json" with { type: "json" };
+import threads from "../schemas/threads.schema.json" with { type: "json" };
 
 interface TableSchema {
   properties?: Record<string, any>;


### PR DESCRIPTION
## Summary
- update `tableSchemas.ts` to use the modern `with` syntax when importing JSON schemas

## Testing
- `npm test` *(fails: Jest cannot parse ES modules)*

------
https://chatgpt.com/codex/tasks/task_e_685844867f108329bb16f8fd245a14c9