### PR TITLE
Handle linked record fields

### DIFF
--- a/api/resolveFieldMap.ts
+++ b/api/resolveFieldMap.ts
@@ -5,6 +5,7 @@ interface TableFieldMap {
   fields: { [key: string]: string };
   searchableFields: string[];
   booleanFields: string[];
+  linkedRecordFields: Record<string, { linkedTable: string; isArray: boolean }>;
 }
 
 function getTableFieldMap(tableName: string): TableFieldMap {
@@ -21,6 +22,7 @@ function getTableFieldMap(tableName: string): TableFieldMap {
         },
         searchableFields: ["phaseId","snapshotMarkdown","keyUpdates","id"],
         booleanFields: [],
+        linkedRecordFields: {},
       };
     case "Contacts":
       return {
@@ -54,6 +56,10 @@ function getTableFieldMap(tableName: string): TableFieldMap {
         },
         searchableFields: ["name","role","company","overview","followupSummary","latestRelatedLog","id"],
         booleanFields: ["followupNeeded"],
+        linkedRecordFields: {
+          linkedLogs: { linkedTable: "Logs", isArray: true },
+          linkedThreads: { linkedTable: "Threads", isArray: true },
+        },
       };
     case "Logs":
       return {
@@ -78,6 +84,10 @@ function getTableFieldMap(tableName: string): TableFieldMap {
         },
         searchableFields: ["summary","content","followupNotes","tags","logId","author"],
         booleanFields: ["followupNeeded"],
+        linkedRecordFields: {
+          linkedContacts: { linkedTable: "Contacts", isArray: true },
+          linkedThreads: { linkedTable: "Threads", isArray: true },
+        },
       };
     case "Threads":
       return {
@@ -102,9 +112,15 @@ function getTableFieldMap(tableName: string): TableFieldMap {
         },
         searchableFields: ["name","description","linkedContactsNames","threadId"],
         booleanFields: [],
+        linkedRecordFields: {
+          linkedContacts: { linkedTable: "Contacts", isArray: true },
+          linkedLogs: { linkedTable: "Logs", isArray: true },
+          parentThread: { linkedTable: "Threads", isArray: true },
+          subthread: { linkedTable: "Threads", isArray: true },
+        },
       };
     default:
-      return { fields: {}, searchableFields: [], booleanFields: [] };
+      return { fields: {}, searchableFields: [], booleanFields: [], linkedRecordFields: {} };
   }
 }
 


### PR DESCRIPTION
## Summary
- track linked record fields in `generateFieldMap.ts`
- embed linked record information in generated `resolveFieldMap`

## Testing
- `npm test` *(fails: Jest encountered unexpected token)*
- `npm run lint` *(fails: 127 problems)*
- `AIRTABLE_TOKEN=dummy AIRTABLE_BASE_ID=dummy node --loader ts-node/esm scripts/generateFieldMap.ts` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_685977f9f0348329856a98e2116e0b38