### PR TITLE
Add linked record resolver utility

### DIFF
--- a/__tests__/resolveLinkedRecordIds.test.ts
+++ b/__tests__/resolveLinkedRecordIds.test.ts
@@ -1,0 +1,15 @@
+import { jest } from '@jest/globals';
+import { resolveLinkedRecordIds } from '../api/resolveLinkedRecordIds';
+import { airtableSearch } from '../api/airtableSearch';
+
+jest.mock('../api/airtableSearch', () => ({
+  airtableSearch: jest.fn(),
+}));
+
+describe('resolveLinkedRecordIds', () => {
+  it('converts display names to record ids', async () => {
+    (airtableSearch as jest.Mock).mockResolvedValueOnce([{ id: 'rec123' }]);
+    const result = await resolveLinkedRecordIds('Contacts', { linkedLogs: ['Log A'] });
+    expect(result.linkedLogs).toEqual(['rec123']);
+  });
+});

--- a/api/resolveLinkedRecordIds.ts
+++ b/api/resolveLinkedRecordIds.ts
@@ -1,0 +1,50 @@
+import { getTableFieldMap } from './resolveFieldMap.js';
+import { airtableSearch } from './airtableSearch.js';
+
+/**
+ * Resolve linked record display names to record IDs.
+ *
+ * @param tableName - Table containing the linked record fields.
+ * @param data - Data object with display name arrays for linked records.
+ * @returns Updated data object with arrays of record IDs.
+ */
+export async function resolveLinkedRecordIds(
+  tableName: string,
+  data: Record<string, any>,
+): Promise<Record<string, any>> {
+  const { linkedRecordFields } = getTableFieldMap(tableName);
+  const result: Record<string, any> = { ...data };
+
+  for (const [fieldKey, cfg] of Object.entries(linkedRecordFields)) {
+    const val = data[fieldKey];
+    if (!val) continue;
+    const names = Array.isArray(val) ? val : [val];
+
+    const { fields: linkedFields } = getTableFieldMap(cfg.linkedTable);
+    const primaryField = linkedFields[Object.keys(linkedFields)[0]];
+    const ids: string[] = [];
+
+    for (const name of names) {
+      const escaped = String(name).replace(/"/g, '\\"');
+      const formula = `LOWER({${primaryField}}) = LOWER("${escaped}")`;
+      const records = await airtableSearch(cfg.linkedTable, formula, {
+        maxRecords: 2,
+      });
+      if (records.length === 0) {
+        throw new Error(
+          `No record in ${cfg.linkedTable} matches "${name}" for field ${fieldKey}`,
+        );
+      }
+      if (records.length > 1) {
+        throw new Error(
+          `Multiple records in ${cfg.linkedTable} match "${name}" for field ${fieldKey}`,
+        );
+      }
+      ids.push(records[0].id);
+    }
+
+    result[fieldKey] = ids;
+  }
+
+  return result;
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,13 @@
+export default {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  globals: {
+    'ts-jest': {
+      useESM: true,
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- support ESM Jest by adding config
- add utility to resolve linked record names to record IDs
- test linked record resolver

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68597d1a837083299201c645f79b8309