### PR TITLE
Ensure linked record IDs resolved before Airtable operations

### DIFF
--- a/api/contacts-id.ts
+++ b/api/contacts-id.ts
@@ -1,6 +1,7 @@
 import getAirtableContext from "./airtable_base.js";
 import { getFieldMap } from "./resolveFieldMap.js";
 import { mapInternalToAirtable } from "./mapRecordFields.js";
+import { resolveLinkedRecordIds } from "./resolveLinkedRecordIds.js";
 
 const idContactsHandler = async (req: any, res: any) => {
   const { base, TABLES, airtableToken, baseId } = getAirtableContext();
@@ -39,7 +40,8 @@ const idContactsHandler = async (req: any, res: any) => {
 
     if (req.method === "PATCH") {
       const fieldMap = getFieldMap(TABLES.CONTACTS);
-      const airtableFields = mapInternalToAirtable(req.body, fieldMap);
+      const resolvedBody = await resolveLinkedRecordIds(TABLES.CONTACTS, req.body);
+      const airtableFields = mapInternalToAirtable(resolvedBody, fieldMap);
 
       const response = await fetch(recordUrl, {
         method: "PATCH",

--- a/api/contacts-index.ts
+++ b/api/contacts-index.ts
@@ -1,6 +1,7 @@
 import getAirtableContext from "./airtable_base.js";
 import { getFieldMap } from "./resolveFieldMap.js";
 import { mapInternalToAirtable } from "./mapRecordFields.js";
+import { resolveLinkedRecordIds } from "./resolveLinkedRecordIds.js";
 import { FieldSet, Record as AirtableRecord } from "airtable";
 
 const apiContactsHandler = async (req: any, res: any) => {
@@ -36,8 +37,9 @@ const apiContactsHandler = async (req: any, res: any) => {
 
     if (req.method === "POST") {
       const fieldMap = getFieldMap(tableName);
-      const airtableFields = mapInternalToAirtable(req.body, fieldMap);
-      
+      const resolvedBody = await resolveLinkedRecordIds(tableName, req.body);
+      const airtableFields = mapInternalToAirtable(resolvedBody, fieldMap);
+
       console.log("Airtable fields being sent:", airtableFields);
 
       const createdRecord = await base(tableName).create([{ fields: airtableFields }]);

--- a/api/log-entries-id.ts
+++ b/api/log-entries-id.ts
@@ -1,6 +1,7 @@
 import getAirtableContext from "./airtable_base.js";
 import { getFieldMap } from "./resolveFieldMap.js";
 import { mapInternalToAirtable } from "./mapRecordFields.js";
+import { resolveLinkedRecordIds } from "./resolveLinkedRecordIds.js";
 
 const idLogEntryHandler = async (req: any, res: any) => {
   const { base, TABLES, airtableToken, baseId } = getAirtableContext();
@@ -38,7 +39,8 @@ const idLogEntryHandler = async (req: any, res: any) => {
 
     if (req.method === "PATCH") {
       const fieldMap = getFieldMap(TABLES.LOGS);
-      const airtableFields = mapInternalToAirtable(req.body, fieldMap);
+      const resolvedBody = await resolveLinkedRecordIds(TABLES.LOGS, req.body);
+      const airtableFields = mapInternalToAirtable(resolvedBody, fieldMap);
 
       const response = await fetch(recordUrl, {
         method: "PATCH",

--- a/api/log-entries-index.ts
+++ b/api/log-entries-index.ts
@@ -1,6 +1,7 @@
 import getAirtableContext from "./airtable_base.js";
 import { getFieldMap } from "./resolveFieldMap.js";
 import { mapInternalToAirtable } from "./mapRecordFields.js";
+import { resolveLinkedRecordIds } from "./resolveLinkedRecordIds.js";
 import { FieldSet, Record as AirtableRecord } from "airtable";
 
 
@@ -41,7 +42,8 @@ const apiLogEntriesHandler = async (req: any, res: any) => {
 
     if (req.method === "POST") {
       const fieldMap = getFieldMap(tableName);
-      const airtableFields = mapInternalToAirtable(req.body, fieldMap);
+      const resolvedBody = await resolveLinkedRecordIds(tableName, req.body);
+      const airtableFields = mapInternalToAirtable(resolvedBody, fieldMap);
 
       const [createdRecord] = await base(tableName).create([{ fields: airtableFields }]);
 

--- a/api/threads-id.ts
+++ b/api/threads-id.ts
@@ -1,6 +1,7 @@
 import getAirtableContext from "./airtable_base.js";
 import { getFieldMap } from "./resolveFieldMap.js";
 import { mapInternalToAirtable } from "./mapRecordFields.js";
+import { resolveLinkedRecordIds } from "./resolveLinkedRecordIds.js";
 
 const idThreadsHandler = async (req: any, res: any) => {
     const { base, TABLES, airtableToken, baseId } = getAirtableContext();
@@ -49,7 +50,8 @@ const idThreadsHandler = async (req: any, res: any) => {
 
         if (req.method === "PATCH") {
             const fieldMap = getFieldMap(TABLES.THREADS);
-            const airtableFields = mapInternalToAirtable(req.body, fieldMap);
+            const resolvedBody = await resolveLinkedRecordIds(TABLES.THREADS, req.body);
+            const airtableFields = mapInternalToAirtable(resolvedBody, fieldMap);
 
             const response = await fetch(recordUrl, {
                 method: "PATCH",

--- a/api/threads-index.ts
+++ b/api/threads-index.ts
@@ -1,6 +1,7 @@
 import getAirtableContext from "./airtable_base.js";
 import { getFieldMap, filterMappedFields } from "./resolveFieldMap.js";
 import { FieldSet, Record as AirtableRecord } from "airtable";
+import { resolveLinkedRecordIds } from "./resolveLinkedRecordIds.js";
 
 
 const apiThreadsHandler = async (req: any, res: any) => {
@@ -40,9 +41,11 @@ const apiThreadsHandler = async (req: any, res: any) => {
 
         if (req.method === "POST") {
             const fieldMap = getFieldMap(tableName);
-            const fields = req.body;
+            const resolvedBody = await resolveLinkedRecordIds(tableName, req.body);
 
-            const createdRecord = await base(tableName).create([{ fields: filterMappedFields({ fields }, fieldMap) }]);
+            const createdRecord = await base(tableName).create([
+                { fields: filterMappedFields({ fields: resolvedBody }, fieldMap) }
+            ]);
 
             return res.status(201).json(createdRecord);
         }


### PR DESCRIPTION
## Summary
- resolve linked IDs in contacts, threads, and log entry endpoints

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68597e9218048329aeba2f09bc4d4255