### PR TITLE
Add record-id format for linked record arrays

### DIFF
--- a/docs/generateFieldMap.md
+++ b/docs/generateFieldMap.md
@@ -51,6 +51,7 @@ Before running:
    * One file per table (e.g. `schemas/contacts.schema.json`)
    * Follows JSON Schema Draft-07 format
    * Contains inferred field types and enum values where possible (from Airtable Metadata)
+   * For linked-record arrays (`multipleRecordLinks`), each `items` schema has `format: "record-id"` to denote Airtable record IDs
 
 3. `custom_action_schema.json` *(planned)*
 

--- a/schemas/contacts.schema.json
+++ b/schemas/contacts.schema.json
@@ -114,7 +114,8 @@
     "linkedLogs": {
       "type": "array",
       "items": {
-        "type": "string"
+        "type": "string",
+        "format": "record-id"
       }
     },
     "linkedLogsSummary": {
@@ -148,7 +149,8 @@
     "linkedThreads": {
       "type": "array",
       "items": {
-        "type": "string"
+        "type": "string",
+        "format": "record-id"
       }
     },
     "linkedThreadsName": {

--- a/schemas/logs.schema.json
+++ b/schemas/logs.schema.json
@@ -9,7 +9,8 @@
     "linkedContacts": {
       "type": "array",
       "items": {
-        "type": "string"
+        "type": "string",
+        "format": "record-id"
       }
     },
     "linkedContactsNames": {
@@ -63,7 +64,8 @@
     "linkedThreads": {
       "type": "array",
       "items": {
-        "type": "string"
+        "type": "string",
+        "format": "record-id"
       }
     },
     "linkedThreadsName": {

--- a/schemas/threads.schema.json
+++ b/schemas/threads.schema.json
@@ -33,7 +33,8 @@
     "linkedContacts": {
       "type": "array",
       "items": {
-        "type": "string"
+        "type": "string",
+        "format": "record-id"
       }
     },
     "linkedContactsNames": {
@@ -46,7 +47,8 @@
     "linkedLogs": {
       "type": "array",
       "items": {
-        "type": "string"
+        "type": "string",
+        "format": "record-id"
       }
     },
     "linkedLogsSummary": {
@@ -72,7 +74,8 @@
     "parentThread": {
       "type": "array",
       "items": {
-        "type": "string"
+        "type": "string",
+        "format": "record-id"
       }
     },
     "parentThreadId": {
@@ -81,7 +84,8 @@
     "subthread": {
       "type": "array",
       "items": {
-        "type": "string"
+        "type": "string",
+        "format": "record-id"
       }
     },
     "subthreadId": {

--- a/scripts/generateFieldMap.ts
+++ b/scripts/generateFieldMap.ts
@@ -59,7 +59,12 @@ function fieldToSchema(field: any): Record<string, any> {
       schema.format = "date-time";
       break;
     case "multipleAttachments":
+      schema.type = "array";
+      break;
     case "multipleRecordLinks":
+      schema.type = "array";
+      schema.items = { type: "string", format: "record-id" };
+      break;
     case "multipleCollaborators":
       schema.type = "array";
       break;


### PR DESCRIPTION
## Summary
- output `format: "record-id"` for `multipleRecordLinks` fields
- document record-id format flag in schema generation docs
- update schema files with the new flag for linked record fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685982f544608329bc8742fef54e522c