### PR TITLE
Add Airtable refresh automation

### DIFF
--- a/.github/workflows/auto-refresh-airtable.yml
+++ b/.github/workflows/auto-refresh-airtable.yml
@@ -1,0 +1,34 @@
+name: Auto refresh Airtable metadata
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm run refresh:airtable
+        env:
+          AIRTABLE_TOKEN: ${{ secrets.AIRTABLE_TOKEN }}
+          AIRTABLE_BASE_ID: ${{ secrets.AIRTABLE_BASE_ID }}
+          AIRTABLE_CONTACTS_TABLE_NAME: ${{ secrets.AIRTABLE_CONTACTS_TABLE_NAME }}
+          AIRTABLE_LOGS_TABLE_NAME: ${{ secrets.AIRTABLE_LOGS_TABLE_NAME }}
+          AIRTABLE_SNAPSHOTS_TABLE_NAME: ${{ secrets.AIRTABLE_SNAPSHOTS_TABLE_NAME }}
+          AIRTABLE_THREADS_TABLE_NAME: ${{ secrets.AIRTABLE_THREADS_TABLE_NAME }}
+      - name: Commit and push changes
+        run: |
+          git config user.name 'github-actions'
+          git config user.email 'github-actions@users.noreply.github.com'
+          if ! git diff --quiet; then
+            git add api/resolveFieldMap.ts custom_action_schema.json
+            git commit -m 'chore: auto-refresh Airtable metadata'
+            git push
+          fi

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "generate:fieldmap": "ts-node scripts/generateFieldMap.ts",
+    "refresh:airtable": "node scripts/refreshAirtable.js",
     "test": "jest"
   },
   "dependencies": {

--- a/scripts/refreshAirtable.js
+++ b/scripts/refreshAirtable.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+import { execSync } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function runScript(script) {
+  const scriptPath = path.join(__dirname, script);
+  execSync(`node --loader ts-node/esm ${scriptPath}`, { stdio: 'inherit' });
+}
+
+function run() {
+  runScript('generateFieldMap.ts');
+  runScript('updateCustomActionParams.ts');
+
+  execSync('git add api/resolveFieldMap.ts custom_action_schema.json', { stdio: 'inherit' });
+
+  try {
+    execSync('git diff --cached --quiet --exit-code');
+    console.log('No changes detected.');
+  } catch {
+    execSync('git commit -m "chore: refresh Airtable field map and schema"', { stdio: 'inherit' });
+    execSync('git push origin main', { stdio: 'inherit' });
+  }
+}
+
+run();


### PR DESCRIPTION
## Summary
- add `refreshAirtable.js` to regenerate field map and schema, then commit & push
- add npm script `refresh:airtable`
- schedule a GitHub Action to automatically refresh Airtable metadata daily

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a857edbc88329a25177e5607ad5c2