### PR TITLE
Fix optional linked table typing

### DIFF
--- a/api/resolveFieldMap.ts
+++ b/api/resolveFieldMap.ts
@@ -5,7 +5,7 @@ interface TableFieldMap {
   fields: { [key: string]: string };
   searchableFields: string[];
   booleanFields: string[];
-  linkedRecordFields: Record<string, { linkedTable: string; isArray: boolean }>;
+  linkedRecordFields: Record<string, { linkedTable?: string; isArray: boolean }>;
 }
 
 function getTableFieldMap(tableName: string): TableFieldMap {

--- a/api/resolveLinkedRecordIds.ts
+++ b/api/resolveLinkedRecordIds.ts
@@ -20,14 +20,14 @@ export async function resolveLinkedRecordIds(
     if (!val) continue;
     const names = Array.isArray(val) ? val : [val];
 
-    const { fields: linkedFields } = getTableFieldMap(cfg.linkedTable);
+    const { fields: linkedFields } = getTableFieldMap(cfg.linkedTable!);
     const primaryField = linkedFields[Object.keys(linkedFields)[0]];
     const ids: string[] = [];
 
     for (const name of names) {
       const escaped = String(name).replace(/"/g, '\\"');
       const formula = `LOWER({${primaryField}}) = LOWER("${escaped}")`;
-      const records = await airtableSearch(cfg.linkedTable, formula, {
+      const records = await airtableSearch(cfg.linkedTable!, formula, {
         maxRecords: 2,
       });
       if (records.length === 0) {

--- a/scripts/generateFieldMap.ts
+++ b/scripts/generateFieldMap.ts
@@ -109,7 +109,7 @@ async function main() {
       fields: Record<string, string>;
       searchableFields: string[];
       booleanFields: string[];
-      linkedRecordFields: Record<string, { linkedTable: string; isArray: boolean }>;
+      linkedRecordFields: Record<string, { linkedTable?: string; isArray: boolean }>;
     }
   > = {};
 
@@ -134,7 +134,7 @@ async function main() {
     const properties: Record<string, any> = {};
     const searchableFields: string[] = [];
     const booleanFields: string[] = [];
-    const linkedRecordFields: Record<string, { linkedTable: string; isArray: boolean }> = {};
+    const linkedRecordFields: Record<string, { linkedTable?: string; isArray: boolean }> = {};
     for (const field of table.fields || []) {
       const key = toCamelCase(field.name);
       mapping[key] = field.name;
@@ -171,7 +171,7 @@ async function main() {
   lines.push("  fields: { [key: string]: string };");
   lines.push("  searchableFields: string[];");
   lines.push("  booleanFields: string[];");
-  lines.push("  linkedRecordFields: Record<string, { linkedTable: string; isArray: boolean }>;" );
+  lines.push("  linkedRecordFields: Record<string, { linkedTable?: string; isArray: boolean }>;" );
   lines.push("}");
   lines.push("");
   lines.push("function getTableFieldMap(tableName: string): TableFieldMap {");


### PR DESCRIPTION
## Summary
- update generated field map typings to allow undefined linked tables
- adapt resolveLinkedRecordIds to use non-null assertion
- update field map generator script

## Testing
- `npm test`
- `npx tsc -p tsconfig.json` *(fails: jest globals and other unrelated errors)*

------
https://chatgpt.com/codex/tasks/task_e_685a876596748329b5a78ce0a62bea29