### PR TITLE
Document Airtable metadata refresh process

### DIFF
--- a/docs/customActions.md
+++ b/docs/customActions.md
@@ -38,6 +38,12 @@ To ensure accuracy, we generate these from real Airtable metadata.
 npx ts-node scripts/generateFieldMap.ts
 ```
 
+You can also run both the generator and schema updater at once:
+
+```bash
+npm run refresh:airtable
+```
+
 This generates:
 
 * `lib/resolveFieldMap.ts` → API-level mapping helper

--- a/docs/generateFieldMap.md
+++ b/docs/generateFieldMap.md
@@ -24,6 +24,16 @@ These outputs are used to ensure:
 node --loader ts-node/esm scripts/generateFieldMap.ts
 ```
 
+You can also trigger this and the related schema update using the
+`refreshAirtable.js` helper script:
+
+```bash
+npm run refresh:airtable
+```
+
+That command runs this generator and `updateCustomActionParams.ts`, then
+commits any resulting changes.
+
 Before running:
 
 * Ensure your `.env` file is configured with the following:

--- a/docs/refreshAirtable.md
+++ b/docs/refreshAirtable.md
@@ -1,0 +1,37 @@
+# 🔄 `refreshAirtable.js`
+
+This short script orchestrates the regeneration of Airtable field mappings and the OpenAPI schema used for GPT custom actions. It runs two existing TypeScript scripts and then commits any changes to the repository.
+
+---
+
+## 🚀 CLI Usage
+
+Run the script through the npm task:
+
+```bash
+npm run refresh:airtable
+```
+
+The command performs the following steps:
+
+1. Executes `scripts/generateFieldMap.ts` and `scripts/updateCustomActionParams.ts`.
+2. Stages the updated `api/resolveFieldMap.ts` and `custom_action_schema.json` files.
+3. If changes were detected, commits with the message `chore: refresh Airtable field map and schema` and pushes to the `main` branch.
+
+Environment variables for the Airtable Metadata API must be available (see `.env.example`).
+
+---
+
+## 🤖 GitHub Actions Workflow
+
+`.github/workflows/auto-refresh-airtable.yml` runs this command automatically every day. The workflow:
+
+1. Checks out the repository and installs dependencies with `npm ci`.
+2. Runs `npm run refresh:airtable` using the Airtable credentials stored in repository secrets.
+3. Commits and pushes any resulting changes back to `main`.
+
+The schedule is defined using a cron expression (`0 0 * * *`) so metadata stays current without manual intervention.
+
+---
+
+Use the CLI command to refresh on demand, or rely on the workflow for daily updates.


### PR DESCRIPTION
## Summary
- document the new `refreshAirtable.js` helper script and daily workflow
- show how to run the script via `npm run refresh:airtable`
- cross-link from existing docs to use the helper script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a87d98b2c83299ab3499014f0b687