### PR TITLE
Fix table name resolution for linked fields

### DIFF
--- a/api/resolveFieldMap.ts
+++ b/api/resolveFieldMap.ts
@@ -58,8 +58,8 @@ function getTableFieldMap(tableName: string): TableFieldMap {
         searchableFields: ["name","role","company","overview","followupSummary","latestRelatedLog","id"],
         booleanFields: ["followupNeeded"],
         linkedRecordFields: {
-          linkedLogs: { linkedTable: undefined, isArray: true },
-          linkedThreads: { linkedTable: undefined, isArray: true },
+          linkedLogs: { linkedTable: "Logs", isArray: true },
+          linkedThreads: { linkedTable: "Threads", isArray: true },
         },
       };
     case "Logs":
@@ -87,8 +87,8 @@ function getTableFieldMap(tableName: string): TableFieldMap {
         searchableFields: ["name","summary","content","followupNotes","tags","logId","author"],
         booleanFields: ["followupNeeded"],
         linkedRecordFields: {
-          linkedContacts: { linkedTable: undefined, isArray: true },
-          linkedThreads: { linkedTable: undefined, isArray: true },
+          linkedContacts: { linkedTable: "Contacts", isArray: true },
+          linkedThreads: { linkedTable: "Threads", isArray: true },
         },
       };
     case "Threads":
@@ -115,10 +115,10 @@ function getTableFieldMap(tableName: string): TableFieldMap {
         searchableFields: ["name","description","linkedContactsNames","threadId"],
         booleanFields: [],
         linkedRecordFields: {
-          linkedContacts: { linkedTable: undefined, isArray: true },
-          linkedLogs: { linkedTable: undefined, isArray: true },
-          parentThread: { linkedTable: undefined, isArray: true },
-          subthread: { linkedTable: undefined, isArray: true },
+          linkedContacts: { linkedTable: "Contacts", isArray: true },
+          linkedLogs: { linkedTable: "Logs", isArray: true },
+          parentThread: { linkedTable: "Threads", isArray: true },
+          subthread: { linkedTable: "Threads", isArray: true },
         },
       };
     default:

--- a/schemas/logs.schema.json
+++ b/schemas/logs.schema.json
@@ -3,10 +3,10 @@
   "title": "Logs",
   "type": "object",
   "properties": {
-    "summary": {
+    "name": {
       "type": "string"
     },
-    "name": {
+    "summary": {
       "type": "string"
     },
     "linkedContacts": {
@@ -28,7 +28,8 @@
         "Call",
         "Meeting",
         "Note",
-        "Email"
+        "Email",
+        "Ritual Run"
       ]
     },
     "date": {

--- a/schemas/threads.schema.json
+++ b/schemas/threads.schema.json
@@ -12,7 +12,8 @@
         "type": "string",
         "enum": [
           "Experiment",
-          "Internal",
+          "Internal: Project",
+          "Internal: Ritual",
           "Output",
           "Collaboration"
         ]

--- a/scripts/generateFieldMap.ts
+++ b/scripts/generateFieldMap.ts
@@ -134,6 +134,12 @@ async function main() {
   const schemaDir = path.join(__dirname, "../schemas");
   fs.mkdirSync(schemaDir, { recursive: true });
 
+  // Map Airtable table IDs to their names so we can resolve linked table names
+  const tableIdToName: Record<string, string> = {};
+  for (const tbl of data.tables || []) {
+    tableIdToName[tbl.id] = tbl.name;
+  }
+
   const allMaps: Record<
     string,
     {
@@ -178,8 +184,9 @@ async function main() {
         booleanFields.push(key);
       }
       if (field.type === "multipleRecordLinks") {
+        const linkedId = field.options?.linkedTableId;
         linkedRecordFields[key] = {
-          linkedTable: field.options?.linkedTableName,
+          linkedTable: linkedId ? tableIdToName[linkedId] : undefined,
           isArray: true,
         };
       }


### PR DESCRIPTION
## Summary
- correctly map linked record fields to table names
- regenerate `resolveFieldMap.ts`
- update example schemas

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685d47d5510c832993a6e91f5b020738