### PR TITLE
Fix linked contact patching when IDs used

### DIFF
--- a/__tests__/resolveLinkedRecordIds.test.ts
+++ b/__tests__/resolveLinkedRecordIds.test.ts
@@ -1,15 +1,26 @@
-import { jest } from '@jest/globals';
-import { resolveLinkedRecordIds } from '../api/resolveLinkedRecordIds';
-import { airtableSearch } from '../api/airtableSearch';
+import { jest } from "@jest/globals";
+import { resolveLinkedRecordIds } from "../api/resolveLinkedRecordIds";
+import { airtableSearch } from "../api/airtableSearch";
 
-jest.mock('../api/airtableSearch', () => ({
+jest.mock("../api/airtableSearch", () => ({
   airtableSearch: jest.fn(),
 }));
 
-describe('resolveLinkedRecordIds', () => {
-  it('converts display names to record ids', async () => {
-    (airtableSearch as jest.Mock).mockResolvedValueOnce([{ id: 'rec123' }]);
-    const result = await resolveLinkedRecordIds('Contacts', { linkedLogs: ['Log A'] });
-    expect(result.linkedLogs).toEqual(['rec123']);
+describe("resolveLinkedRecordIds", () => {
+  it("converts display names to record ids", async () => {
+    (airtableSearch as jest.Mock).mockResolvedValueOnce([{ id: "rec123" }]);
+    const result = await resolveLinkedRecordIds("Contacts", {
+      linkedLogs: ["Log A"],
+    });
+    expect(result.linkedLogs).toEqual(["rec123"]);
+  });
+
+  it("passes record ids through unchanged", async () => {
+    (airtableSearch as jest.Mock).mockClear();
+    const result = await resolveLinkedRecordIds("Contacts", {
+      linkedLogs: ["rec12345678901234"],
+    });
+    expect(result.linkedLogs).toEqual(["rec12345678901234"]);
+    expect(airtableSearch).not.toHaveBeenCalled();
   });
 });

--- a/api/resolveLinkedRecordIds.ts
+++ b/api/resolveLinkedRecordIds.ts
@@ -1,5 +1,5 @@
-import { getTableFieldMap } from './resolveFieldMap.js';
-import { airtableSearch } from './airtableSearch.js';
+import { getTableFieldMap } from "./resolveFieldMap.js";
+import { airtableSearch } from "./airtableSearch.js";
 
 /**
  * Resolve linked record display names to record IDs.
@@ -15,29 +15,36 @@ export async function resolveLinkedRecordIds(
   const { linkedRecordFields } = getTableFieldMap(tableName);
   const result: Record<string, any> = { ...data };
 
+  const recordIdRegex = /^rec[A-Za-z0-9]{14}$/;
+
   for (const [fieldKey, cfg] of Object.entries(linkedRecordFields)) {
     const val = data[fieldKey];
     if (!val) continue;
-    const names = Array.isArray(val) ? val : [val];
+    const values = Array.isArray(val) ? val : [val];
 
     const { fields: linkedFields } = getTableFieldMap(cfg.linkedTable!);
     const primaryField = linkedFields[Object.keys(linkedFields)[0]];
     const ids: string[] = [];
 
-    for (const name of names) {
-      const escaped = String(name).replace(/"/g, '\\"');
+    for (const value of values) {
+      if (typeof value === "string" && recordIdRegex.test(value)) {
+        ids.push(value);
+        continue;
+      }
+
+      const escaped = String(value).replace(/"/g, '\\"');
       const formula = `LOWER({${primaryField}}) = LOWER("${escaped}")`;
       const records = await airtableSearch(cfg.linkedTable!, formula, {
         maxRecords: 2,
       });
       if (records.length === 0) {
         throw new Error(
-          `No record in ${cfg.linkedTable} matches "${name}" for field ${fieldKey}`,
+          `No record in ${cfg.linkedTable} matches "${value}" for field ${fieldKey}`,
         );
       }
       if (records.length > 1) {
         throw new Error(
-          `Multiple records in ${cfg.linkedTable} match "${name}" for field ${fieldKey}`,
+          `Multiple records in ${cfg.linkedTable} match "${value}" for field ${fieldKey}`,
         );
       }
       ids.push(records[0].id);


### PR DESCRIPTION
## Summary
- allow resolveLinkedRecordIds to accept Airtable record IDs directly
- test passing record IDs through without lookup

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685d53d3f9808329a63250804bc47896