### PR TITLE
Add endpoint to link threads

### DIFF
--- a/__tests__/resolveLinkedRecordIds.test.ts
+++ b/__tests__/resolveLinkedRecordIds.test.ts
@@ -1,5 +1,5 @@
 import { jest } from "@jest/globals";
-import { resolveLinkedRecordIds } from "../api/resolveLinkedRecordIds";
+import { resolveLinkedRecordIds, resolveRecordId } from "../api/resolveLinkedRecordIds";
 import { airtableSearch } from "../api/airtableSearch";
 
 jest.mock("../api/airtableSearch", () => ({
@@ -21,6 +21,21 @@ describe("resolveLinkedRecordIds", () => {
       linkedLogs: ["rec12345678901234"],
     });
     expect(result.linkedLogs).toEqual(["rec12345678901234"]);
+    expect(airtableSearch).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveRecordId", () => {
+  it("resolves a name to an id", async () => {
+    (airtableSearch as jest.Mock).mockResolvedValueOnce([{ id: "rec789" }]);
+    const id = await resolveRecordId("Threads", "My Thread");
+    expect(id).toBe("rec789");
+  });
+
+  it("returns the id when provided", async () => {
+    (airtableSearch as jest.Mock).mockClear();
+    const id = await resolveRecordId("Threads", "rec12345678901234");
+    expect(id).toBe("rec12345678901234");
     expect(airtableSearch).not.toHaveBeenCalled();
   });
 });

--- a/api/resolveLinkedRecordIds.ts
+++ b/api/resolveLinkedRecordIds.ts
@@ -8,6 +8,28 @@ import { airtableSearch } from "./airtableSearch.js";
  * @param data - Data object with display name arrays for linked records.
  * @returns Updated data object with arrays of record IDs.
  */
+export async function resolveRecordId(
+  tableName: string,
+  value: string,
+): Promise<string> {
+  const { fields } = getTableFieldMap(tableName);
+  const primaryField = fields[Object.keys(fields)[0]];
+  const recordIdRegex = /^rec[A-Za-z0-9]{14}$/;
+
+  if (recordIdRegex.test(value)) return value;
+
+  const escaped = value.replace(/"/g, '\\"');
+  const formula = `LOWER({${primaryField}}) = LOWER("${escaped}")`;
+  const records = await airtableSearch(tableName, formula, { maxRecords: 2 });
+  if (records.length === 0) {
+    throw new Error(`No record in ${tableName} matches "${value}"`);
+  }
+  if (records.length > 1) {
+    throw new Error(`Multiple records in ${tableName} match "${value}"`);
+  }
+  return records[0].id;
+}
+
 export async function resolveLinkedRecordIds(
   tableName: string,
   data: Record<string, any>,
@@ -15,39 +37,14 @@ export async function resolveLinkedRecordIds(
   const { linkedRecordFields } = getTableFieldMap(tableName);
   const result: Record<string, any> = { ...data };
 
-  const recordIdRegex = /^rec[A-Za-z0-9]{14}$/;
-
   for (const [fieldKey, cfg] of Object.entries(linkedRecordFields)) {
     const val = data[fieldKey];
     if (!val) continue;
     const values = Array.isArray(val) ? val : [val];
 
-    const { fields: linkedFields } = getTableFieldMap(cfg.linkedTable!);
-    const primaryField = linkedFields[Object.keys(linkedFields)[0]];
     const ids: string[] = [];
-
     for (const value of values) {
-      if (typeof value === "string" && recordIdRegex.test(value)) {
-        ids.push(value);
-        continue;
-      }
-
-      const escaped = String(value).replace(/"/g, '\\"');
-      const formula = `LOWER({${primaryField}}) = LOWER("${escaped}")`;
-      const records = await airtableSearch(cfg.linkedTable!, formula, {
-        maxRecords: 2,
-      });
-      if (records.length === 0) {
-        throw new Error(
-          `No record in ${cfg.linkedTable} matches "${value}" for field ${fieldKey}`,
-        );
-      }
-      if (records.length > 1) {
-        throw new Error(
-          `Multiple records in ${cfg.linkedTable} match "${value}" for field ${fieldKey}`,
-        );
-      }
-      ids.push(records[0].id);
+      ids.push(await resolveRecordId(cfg.linkedTable!, String(value)));
     }
 
     result[fieldKey] = ids;

--- a/api/threads-link.ts
+++ b/api/threads-link.ts
@@ -1,0 +1,55 @@
+import getAirtableContext from "./airtable_base.js";
+import { getFieldMap } from "./resolveFieldMap.js";
+import { mapInternalToAirtable } from "./mapRecordFields.js";
+import { resolveRecordId } from "./resolveLinkedRecordIds.js";
+
+const threadsLinkHandler = async (req: any, res: any) => {
+  const { baseId, airtableToken, TABLES } = getAirtableContext();
+  const tableName = TABLES.THREADS;
+
+  if (req.method !== "POST") {
+    res.setHeader("Allow", ["POST"]);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+
+  const { childThread, parentThread, linkType } = req.body || {};
+  if (!childThread || !parentThread || !linkType) {
+    return res.status(400).json({ error: "childThread, parentThread and linkType are required" });
+  }
+  if (linkType !== "parent" && linkType !== "subthread") {
+    return res.status(400).json({ error: "linkType must be 'parent' or 'subthread'" });
+  }
+
+  try {
+    const childId = await resolveRecordId(tableName, String(childThread));
+    const parentId = await resolveRecordId(tableName, String(parentThread));
+
+    const recordId = linkType === "parent" ? childId : parentId;
+    const updateData = linkType === "parent"
+      ? { parentThread: [parentId] }
+      : { subthread: [childId] };
+
+    const fieldMap = getFieldMap(tableName);
+    const airtableFields = mapInternalToAirtable(updateData, fieldMap);
+    const recordUrl = `https://api.airtable.com/v0/${baseId}/${encodeURIComponent(tableName)}/${recordId}`;
+    const headers = {
+      Authorization: `Bearer ${airtableToken}`,
+      "Content-Type": "application/json",
+    };
+    const response = await fetch(recordUrl, {
+      method: "PATCH",
+      headers,
+      body: JSON.stringify({ fields: airtableFields }),
+    });
+    if (!response.ok) {
+      return res.status(response.status).json({ error: await response.text() });
+    }
+
+    return res.status(200).json({ message: "Thread link updated" });
+  } catch (error: any) {
+    console.error("API error:", error);
+    return res.status(500).json({ error: error.message || "Internal Server Error" });
+  }
+};
+
+export default threadsLinkHandler;

--- a/custom_action_schema.json
+++ b/custom_action_schema.json
@@ -1199,6 +1199,44 @@
         }
       }
     },
+    "/api/threads-link": {
+      "post": {
+        "operationId": "linkThreads",
+        "summary": "Add a parent thread or subthread",
+        "description": "Link two existing threads by setting a parent or subthread relationship. Thread names or record IDs are accepted and resolved automatically.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "childThread": {
+                    "type": "string",
+                    "description": "Child thread name or record ID"
+                  },
+                  "parentThread": {
+                    "type": "string",
+                    "description": "Parent thread name or record ID"
+                  },
+                  "linkType": {
+                    "type": "string",
+                    "enum": ["parent", "subthread"],
+                    "description": "Choose 'parent' to set a parent on the child thread or 'subthread' to add a subthread to the parent thread"
+                  }
+                },
+                "required": ["childThread", "parentThread", "linkType"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Link updated"
+          }
+        }
+      }
+    },
     "/api/log-entries-index": {
       "get": {
         "operationId": "getAllLogs",


### PR DESCRIPTION
## Summary
- add `resolveRecordId` helper to convert a name or ID to a record id
- create `threads-link` API endpoint to attach parent threads or subthreads
- document new endpoint in `custom_action_schema.json`
- extend tests for new helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d63e18b5c8329bdef8a878e70ed91