### PR TITLE
Fix field references in synthesis

### DIFF
--- a/api/synthesisUtils.ts
+++ b/api/synthesisUtils.ts
@@ -16,13 +16,15 @@ export async function synthesizeThreadNarrative(threadId: string) {
     // Fetch all logs linked to the given thread
     const logRecords = await base(TABLES.LOGS)
         .select({
-            filterByFormula: `FIND("${threadId}", ARRAYJOIN(${logFieldMap["Thread (Linked)"]}))`,
-            fields: [logFieldMap["Content"]],
-            sort: [{ field: logFieldMap["Date"], direction: "asc" }]
+            filterByFormula: `FIND("${threadId}", ARRAYJOIN({${logFieldMap.linkedThreads}}))`,
+            fields: [logFieldMap.content],
+            sort: [{ field: logFieldMap.date, direction: "asc" }]
         })
         .all();
 
-    const logContentArray = logRecords.map((record: any) => record.fields?.[logFieldMap["Content"]]).filter(Boolean);
+    const logContentArray = logRecords
+        .map((record: any) => record.fields?.[logFieldMap.content])
+        .filter(Boolean);
 
     const logContent = logContentArray.join("\n\n").trim();
 


### PR DESCRIPTION
## Summary
- reference the proper field keys from `resolveFieldMap.ts`
- ensure logs filter correctly using `linkedThreads`, `content`, and `date`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e65eba12883299ca97d570ede9a18