### PR TITLE
Add synthesis endpoints to OpenAPI

### DIFF
--- a/custom_action_schema.json
+++ b/custom_action_schema.json
@@ -1221,11 +1221,18 @@
                   },
                   "linkType": {
                     "type": "string",
-                    "enum": ["parent", "subthread"],
+                    "enum": [
+                      "parent",
+                      "subthread"
+                    ],
                     "description": "Choose 'parent' to set a parent on the child thread or 'subthread' to add a subthread to the parent thread"
                   }
                 },
-                "required": ["childThread", "parentThread", "linkType"]
+                "required": [
+                  "childThread",
+                  "parentThread",
+                  "linkType"
+                ]
               }
             }
           }
@@ -1506,6 +1513,49 @@
         "responses": {
           "200": {
             "description": "The updated log entry"
+          }
+        }
+      }
+    },
+    "/api/snapshots-synthesize-current-state": {
+      "get": {
+        "operationId": "synthesizeCurrentState",
+        "summary": "Synthesize latest snapshot",
+        "description": "Return the most recent snapshot with fields filtered by the field map.",
+        "responses": {
+          "200": {
+            "description": "Latest snapshot"
+          }
+        }
+      }
+    },
+    "/api/synthesize-thread": {
+      "post": {
+        "operationId": "synthesizeThread",
+        "summary": "Generate a thread synthesis",
+        "description": "Fetch logs and contacts for a thread, run GPT synthesis, store the result as a log entry, and return the text.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "threadId": {
+                    "type": "string",
+                    "description": "Thread record ID"
+                  }
+                },
+                "required": [
+                  "threadId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Synthesis generated"
           }
         }
       }

--- a/scripts/updateCustomActionParams.ts
+++ b/scripts/updateCustomActionParams.ts
@@ -38,6 +38,8 @@ const tableNames: Record<string, string> = {
   "/api/snapshots-id": process.env.AIRTABLE_SNAPSHOTS_TABLE_NAME || "Cold Snapshots",
   "/api/threads-index": process.env.AIRTABLE_THREADS_TABLE_NAME || "Threads",
   "/api/threads-id": process.env.AIRTABLE_THREADS_TABLE_NAME || "Threads",
+  "/api/snapshots-synthesize-current-state": process.env.AIRTABLE_SNAPSHOTS_TABLE_NAME || "Cold Snapshots",
+  "/api/synthesize-thread": process.env.AIRTABLE_THREADS_TABLE_NAME || "Threads",
 };
 
 


### PR DESCRIPTION
## Summary
- expose `/api/snapshots-synthesize-current-state` and `/api/synthesize-thread` in OpenAPI spec
- update `updateCustomActionParams.ts` mapping so the script is aware of these endpoints

## Testing
- `npm test`
- `npm run lint` *(fails: 137 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685e6979aee883298c7938e79811b8c9