### PR TITLE
Add pagination support to log entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,13 @@ Two routes help generate GPT summaries:
 2. **POST `/api/synthesize-thread`** – builds a prompt from a thread, calls GPT‑4 and saves the result as a log entry.
 
 See [docs/synthesisEndpoints.md](docs/synthesisEndpoints.md) for examples and more details.
+
+### `GET /api/log-entries-index`
+
+List log entries with optional pagination.
+
+```bash
+curl "https://your-domain.com/api/log-entries-index?limit=5"
+```
+
+The response includes a list of records and an `offset` token for fetching the next page.

--- a/__tests__/logEntriesIndex.test.ts
+++ b/__tests__/logEntriesIndex.test.ts
@@ -1,0 +1,43 @@
+import { jest } from "@jest/globals";
+import logEntriesHandler from "../api/log-entries-index";
+import getAirtableContext from "../api/airtable_base";
+import { getFieldMap } from "../api/resolveFieldMap";
+import { airtableSearch } from "../api/airtableSearch";
+
+jest.mock("../api/airtable_base");
+jest.mock("../api/resolveFieldMap");
+jest.mock("../api/airtableSearch");
+
+const json = jest.fn();
+const status = jest.fn(() => ({ json }));
+const res = { status } as any;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+it("honors limit parameter", async () => {
+  (getAirtableContext as jest.Mock).mockReturnValue({
+    TABLES: { LOGS: "Logs" },
+    base: jest.fn(),
+    airtableToken: "tok",
+    baseId: "base",
+  });
+  (getFieldMap as jest.Mock).mockReturnValue({ summary: "Summary" });
+  (airtableSearch as jest.Mock).mockResolvedValue({
+    records: [{ id: "rec1", fields: { Summary: "hello" } }],
+    offset: "next",
+  });
+
+  await logEntriesHandler({ method: "GET", query: { limit: "5" } } as any, res);
+
+  expect(airtableSearch).toHaveBeenCalledWith("Logs", "", {
+    maxRecords: 5,
+    offset: undefined,
+  });
+  expect(status).toHaveBeenCalledWith(200);
+  expect(json).toHaveBeenCalledWith({
+    records: [{ id: "rec1", summary: "hello" }],
+    offset: "next",
+  });
+});

--- a/__tests__/resolveLinkedRecordIds.test.ts
+++ b/__tests__/resolveLinkedRecordIds.test.ts
@@ -1,5 +1,8 @@
 import { jest } from "@jest/globals";
-import { resolveLinkedRecordIds, resolveRecordId } from "../api/resolveLinkedRecordIds";
+import {
+  resolveLinkedRecordIds,
+  resolveRecordId,
+} from "../api/resolveLinkedRecordIds";
 import { airtableSearch } from "../api/airtableSearch";
 
 jest.mock("../api/airtableSearch", () => ({
@@ -8,7 +11,10 @@ jest.mock("../api/airtableSearch", () => ({
 
 describe("resolveLinkedRecordIds", () => {
   it("converts display names to record ids", async () => {
-    (airtableSearch as jest.Mock).mockResolvedValueOnce([{ id: "rec123" }]);
+    (airtableSearch as jest.Mock).mockResolvedValueOnce({
+      records: [{ id: "rec123" }],
+      offset: undefined,
+    });
     const result = await resolveLinkedRecordIds("Contacts", {
       linkedLogs: ["Log A"],
     });
@@ -27,7 +33,10 @@ describe("resolveLinkedRecordIds", () => {
 
 describe("resolveRecordId", () => {
   it("resolves a name to an id", async () => {
-    (airtableSearch as jest.Mock).mockResolvedValueOnce([{ id: "rec789" }]);
+    (airtableSearch as jest.Mock).mockResolvedValueOnce({
+      records: [{ id: "rec789" }],
+      offset: undefined,
+    });
     const id = await resolveRecordId("Threads", "My Thread");
     expect(id).toBe("rec789");
   });

--- a/api/dynamicSearchHandler.ts
+++ b/api/dynamicSearchHandler.ts
@@ -57,7 +57,7 @@ export function createDynamicSearchHandler(tableName: string) {
     }
 
     try {
-      const records = await airtableSearch(tableName, formula, options);
+      const { records } = await airtableSearch(tableName, formula, options);
       if (!records || records.length === 0) {
         return res.status(404).json({ message: "No matching record found" });
       }

--- a/api/resolveLinkedRecordIds.ts
+++ b/api/resolveLinkedRecordIds.ts
@@ -20,7 +20,9 @@ export async function resolveRecordId(
 
   const escaped = value.replace(/"/g, '\\"');
   const formula = `LOWER({${primaryField}}) = LOWER("${escaped}")`;
-  const records = await airtableSearch(tableName, formula, { maxRecords: 2 });
+  const { records } = await airtableSearch(tableName, formula, {
+    maxRecords: 2,
+  });
   if (records.length === 0) {
     throw new Error(`No record in ${tableName} matches "${value}"`);
   }

--- a/custom_action_schema.json
+++ b/custom_action_schema.json
@@ -68,9 +68,7 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "message"
-                  ]
+                  "required": ["message"]
                 }
               }
             }
@@ -340,12 +338,7 @@
                   },
                   "relationshipStrength": {
                     "type": "string",
-                    "enum": [
-                      "Cold",
-                      "Weak",
-                      "Warm",
-                      "Strong"
-                    ],
+                    "enum": ["Cold", "Weak", "Warm", "Strong"],
                     "description": "This field must be provided as a single string value (not an array). Choose one value from the list of allowed options. Example: \"Cold\""
                   },
                   "status": {
@@ -622,12 +615,7 @@
                   },
                   "relationshipStrength": {
                     "type": "string",
-                    "enum": [
-                      "Cold",
-                      "Weak",
-                      "Warm",
-                      "Strong"
-                    ],
+                    "enum": ["Cold", "Weak", "Warm", "Strong"],
                     "description": "This field must be provided as a single string value (not an array). Choose one value from the list of allowed options. Example: \"Strong\""
                   },
                   "status": {
@@ -766,12 +754,7 @@
                       },
                       "status": {
                         "type": "string",
-                        "enum": [
-                          "Idea",
-                          "In Progress",
-                          "Paused",
-                          "Complete"
-                        ],
+                        "enum": ["Idea", "In Progress", "Paused", "Complete"],
                         "description": "This field must be provided as a single string value (not an array). Choose one value from the list of allowed options. Example: \"Idea\""
                       },
                       "description": {
@@ -846,12 +829,7 @@
                   },
                   "status": {
                     "type": "string",
-                    "enum": [
-                      "Idea",
-                      "In Progress",
-                      "Paused",
-                      "Complete"
-                    ],
+                    "enum": ["Idea", "In Progress", "Paused", "Complete"],
                     "description": "This field must be provided as a single string value (not an array). Choose one value from the list of allowed options. Example: \"Idea\""
                   },
                   "description": {
@@ -982,12 +960,7 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": [
-                        "Idea",
-                        "In Progress",
-                        "Paused",
-                        "Complete"
-                      ],
+                      "enum": ["Idea", "In Progress", "Paused", "Complete"],
                       "description": "This field must be provided as a single string value (not an array). Choose one value from the list of allowed options. Example: \"Idea\""
                     },
                     "description": {
@@ -1070,12 +1043,7 @@
                   },
                   "status": {
                     "type": "string",
-                    "enum": [
-                      "Idea",
-                      "In Progress",
-                      "Paused",
-                      "Complete"
-                    ],
+                    "enum": ["Idea", "In Progress", "Paused", "Complete"],
                     "description": "This field must be provided as a single string value (not an array). Choose one value from the list of allowed options. Example: \"Idea\""
                   },
                   "description": {
@@ -1177,12 +1145,7 @@
                       },
                       "status": {
                         "type": "string",
-                        "enum": [
-                          "Idea",
-                          "In Progress",
-                          "Paused",
-                          "Complete"
-                        ],
+                        "enum": ["Idea", "In Progress", "Paused", "Complete"],
                         "description": "This field must be provided as a single string value (not an array). Choose one value from the list of allowed options. Example: \"Idea\""
                       },
                       "description": {
@@ -1251,18 +1214,11 @@
                   },
                   "linkType": {
                     "type": "string",
-                    "enum": [
-                      "parent",
-                      "subthread"
-                    ],
+                    "enum": ["parent", "subthread"],
                     "description": "Choose 'parent' to set a parent on the child thread or 'subthread' to add a subthread to the parent thread"
                   }
                 },
-                "required": [
-                  "childThread",
-                  "parentThread",
-                  "linkType"
-                ]
+                "required": ["childThread", "parentThread", "linkType"]
               }
             }
           }
@@ -1279,6 +1235,18 @@
         "operationId": "getAllLogs",
         "summary": "List log entries",
         "description": "Fetch all log entries from the Logs database.",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer", "minimum": 1 }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": { "type": "string" }
+          }
+        ],
         "responses": {
           "200": {
             "description": "A list of log entries"
@@ -1312,13 +1280,7 @@
                   },
                   "logType": {
                     "type": "string",
-                    "enum": [
-                      "Call",
-                      "Meeting",
-                      "Note",
-                      "Email",
-                      "Ritual Run"
-                    ]
+                    "enum": ["Call", "Meeting", "Note", "Email", "Ritual Run"]
                   },
                   "date": {
                     "type": "string",
@@ -1500,13 +1462,7 @@
                   },
                   "logType": {
                     "type": "string",
-                    "enum": [
-                      "Call",
-                      "Meeting",
-                      "Note",
-                      "Email",
-                      "Ritual Run"
-                    ],
+                    "enum": ["Call", "Meeting", "Note", "Email", "Ritual Run"],
                     "description": "This field must be provided as a single string value (not an array). Choose one value from the list of allowed options. Example: \"Evemt\""
                   },
                   "date": {
@@ -1582,9 +1538,7 @@
                     "description": "Thread record ID"
                   }
                 },
-                "required": [
-                  "threadId"
-                ]
+                "required": ["threadId"]
               }
             }
           }


### PR DESCRIPTION
## Summary
- add optional `limit` and `offset` parameters to the logs index route
- return Airtable pagination token from `log-entries-index`
- extend `airtableSearch` to support `offset`
- update OpenAPI schema and documentation
- add tests for new behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867ef785a648329bfcc4de6c7d463cd