### PR TITLE
chore: guard airtable refresh if secrets missing

### DIFF
--- a/.github/workflows/auto-refresh-airtable.yml
+++ b/.github/workflows/auto-refresh-airtable.yml
@@ -22,7 +22,14 @@ jobs:
         with:
           node-version: '20'
       - run: npm ci
+      - name: Validate Airtable env vars
+        run: |
+          if [[ -z "$AIRTABLE_TOKEN" || -z "$AIRTABLE_BASE_ID" ]]; then
+            echo "Required Airtable secrets missing, skipping refresh"
+            exit 0
+          fi
       - run: npm run refresh:airtable
+        if: ${{ env.AIRTABLE_TOKEN != '' && env.AIRTABLE_BASE_ID != '' }}
       - name: Commit and push changes
         run: |
           git config user.name 'github-actions'


### PR DESCRIPTION
## Summary
- guard auto-refresh Airtable job when secrets missing to avoid failing workflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689470a5cd2c8329b0c5b6e515ad5576