### PR TITLE
feat: scrub payload before Airtable writes

### DIFF
--- a/__tests__/scrubPayload.test.ts
+++ b/__tests__/scrubPayload.test.ts
@@ -1,0 +1,15 @@
+import { scrubPayload } from "../api/scrubPayload";
+
+describe("scrubPayload", () => {
+  it("removes read-only and unknown fields", async () => {
+    const payload = {
+      name: "Alice",
+      id: "rec123",
+      created: "2024-01-01",
+      lastModified: "2024-02-01",
+      extra: "ignore",
+    };
+    const cleaned = await scrubPayload("Contacts", payload);
+    expect(cleaned).toEqual({ name: "Alice" });
+  });
+});

--- a/api/contacts-id.ts
+++ b/api/contacts-id.ts
@@ -2,6 +2,7 @@ import getAirtableContext from "./airtable_base.js";
 import { getFieldMap } from "./resolveFieldMap.js";
 import { mapInternalToAirtable } from "./mapRecordFields.js";
 import { resolveLinkedRecordIds } from "./resolveLinkedRecordIds.js";
+import { scrubPayload } from "./scrubPayload.js";
 
 const idContactsHandler = async (req: any, res: any) => {
   const { base, TABLES, airtableToken, baseId } = getAirtableContext();
@@ -41,7 +42,8 @@ const idContactsHandler = async (req: any, res: any) => {
     if (req.method === "PATCH") {
       const fieldMap = getFieldMap(TABLES.CONTACTS);
       const resolvedBody = await resolveLinkedRecordIds(TABLES.CONTACTS, req.body);
-      const airtableFields = mapInternalToAirtable(resolvedBody, fieldMap);
+      const scrubbedBody = await scrubPayload(TABLES.CONTACTS, resolvedBody);
+      const airtableFields = mapInternalToAirtable(scrubbedBody, fieldMap);
 
       const response = await fetch(recordUrl, {
         method: "PATCH",

--- a/api/contacts-index.ts
+++ b/api/contacts-index.ts
@@ -3,6 +3,7 @@ import { getFieldMap } from "./resolveFieldMap.js";
 import { mapInternalToAirtable } from "./mapRecordFields.js";
 import { resolveLinkedRecordIds } from "./resolveLinkedRecordIds.js";
 import { FieldSet, Record as AirtableRecord } from "airtable";
+import { scrubPayload } from "./scrubPayload.js";
 
 const apiContactsHandler = async (req: any, res: any) => {
   const { base, TABLES, airtableToken, baseId } = getAirtableContext();
@@ -38,7 +39,8 @@ const apiContactsHandler = async (req: any, res: any) => {
     if (req.method === "POST") {
       const fieldMap = getFieldMap(tableName);
       const resolvedBody = await resolveLinkedRecordIds(tableName, req.body);
-      const airtableFields = mapInternalToAirtable(resolvedBody, fieldMap);
+      const scrubbedBody = await scrubPayload(tableName, resolvedBody);
+      const airtableFields = mapInternalToAirtable(scrubbedBody, fieldMap);
 
       console.log("Airtable fields being sent:", airtableFields);
 

--- a/api/log-entries-id.ts
+++ b/api/log-entries-id.ts
@@ -2,6 +2,7 @@ import getAirtableContext from "./airtable_base.js";
 import { getFieldMap } from "./resolveFieldMap.js";
 import { mapInternalToAirtable } from "./mapRecordFields.js";
 import { resolveLinkedRecordIds } from "./resolveLinkedRecordIds.js";
+import { scrubPayload } from "./scrubPayload.js";
 
 const idLogEntryHandler = async (req: any, res: any) => {
   const { base, TABLES, airtableToken, baseId } = getAirtableContext();
@@ -40,7 +41,8 @@ const idLogEntryHandler = async (req: any, res: any) => {
     if (req.method === "PATCH") {
       const fieldMap = getFieldMap(TABLES.LOGS);
       const resolvedBody = await resolveLinkedRecordIds(TABLES.LOGS, req.body);
-      const airtableFields = mapInternalToAirtable(resolvedBody, fieldMap);
+      const scrubbedBody = await scrubPayload(TABLES.LOGS, resolvedBody);
+      const airtableFields = mapInternalToAirtable(scrubbedBody, fieldMap);
 
       const response = await fetch(recordUrl, {
         method: "PATCH",

--- a/api/log-entries-index.ts
+++ b/api/log-entries-index.ts
@@ -3,6 +3,7 @@ import { getFieldMap } from "./resolveFieldMap.js";
 import { mapInternalToAirtable } from "./mapRecordFields.js";
 import { resolveLinkedRecordIds } from "./resolveLinkedRecordIds.js";
 import { airtableSearch } from "./airtableSearch.js";
+import { scrubPayload } from "./scrubPayload.js";
 
 const apiLogEntriesHandler = async (req: any, res: any) => {
   const { base, TABLES, airtableToken, baseId } = getAirtableContext();
@@ -57,7 +58,8 @@ const apiLogEntriesHandler = async (req: any, res: any) => {
     if (req.method === "POST") {
       const fieldMap = getFieldMap(tableName);
       const resolvedBody = await resolveLinkedRecordIds(tableName, req.body);
-      const airtableFields = mapInternalToAirtable(resolvedBody, fieldMap);
+      const scrubbedBody = await scrubPayload(tableName, resolvedBody);
+      const airtableFields = mapInternalToAirtable(scrubbedBody, fieldMap);
 
       const [createdRecord] = await base(tableName).create([
         { fields: airtableFields },

--- a/api/scrubPayload.ts
+++ b/api/scrubPayload.ts
@@ -1,0 +1,44 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+const writableCache = new Map<string, Set<string>>();
+
+function toSchemaFileName(entity: string): string {
+  const noSpaces = entity.replace(/\s+/g, "");
+  return noSpaces.charAt(0).toLowerCase() + noSpaces.slice(1);
+}
+
+async function getWritableFields(entity: string): Promise<Set<string>> {
+  if (writableCache.has(entity)) {
+    return writableCache.get(entity)!;
+  }
+  try {
+    const schemaFile = toSchemaFileName(entity);
+    const schemaPath = path.join(process.cwd(), "schemas", `${schemaFile}.schema.json`);
+    const content = await readFile(schemaPath, "utf-8");
+    const schema = JSON.parse(content);
+    const props = schema.properties || {};
+    const writable = new Set<string>();
+    for (const [key, def] of Object.entries<any>(props)) {
+      if (!def.readOnly) writable.add(key);
+    }
+    writableCache.set(entity, writable);
+    return writable;
+  } catch (err) {
+    console.error(`Failed to load schema for ${entity}:`, err);
+    const empty = new Set<string>();
+    writableCache.set(entity, empty);
+    return empty;
+  }
+}
+
+export async function scrubPayload(entity: string, payload: Record<string, any>): Promise<Record<string, any>> {
+  const writable = await getWritableFields(entity);
+  const clean: Record<string, any> = {};
+  for (const [key, value] of Object.entries(payload || {})) {
+    if (writable.has(key)) {
+      clean[key] = value;
+    }
+  }
+  return clean;
+}

--- a/api/snapshots-id.ts
+++ b/api/snapshots-id.ts
@@ -1,6 +1,7 @@
 import getAirtableContext from "./airtable_base.js";
 import { getFieldMap } from "./resolveFieldMap.js";
 import { mapInternalToAirtable } from "./mapRecordFields.js";
+import { scrubPayload } from "./scrubPayload.js";
 
 const idSnapshotsHandler = async (req: any, res: any) => {
     const { base, TABLES, airtableToken, baseId } = getAirtableContext();
@@ -38,7 +39,8 @@ const idSnapshotsHandler = async (req: any, res: any) => {
 
         if (req.method === "PATCH") {
             const fieldMap = getFieldMap(TABLES.SNAPSHOTS);
-            const airtableFields = mapInternalToAirtable(req.body, fieldMap);
+            const scrubbedBody = await scrubPayload(TABLES.SNAPSHOTS, req.body);
+            const airtableFields = mapInternalToAirtable(scrubbedBody, fieldMap);
 
             const response = await fetch(recordUrl, {
                 method: "PATCH",

--- a/api/snapshots-index.ts
+++ b/api/snapshots-index.ts
@@ -2,6 +2,7 @@ import getAirtableContext from "./airtable_base.js";
 import { getFieldMap } from "./resolveFieldMap.js";
 import { mapInternalToAirtable } from "./mapRecordFields.js";
 import { FieldSet, Record as AirtableRecord } from "airtable";
+import { scrubPayload } from "./scrubPayload.js";
 
 
 const apiSnapshotsHandler = async (req: any, res: any) => {
@@ -41,7 +42,8 @@ const apiSnapshotsHandler = async (req: any, res: any) => {
 
         if (req.method === "POST") {
             const fieldMap = getFieldMap(tableName);
-            const airtableFields = mapInternalToAirtable(req.body, fieldMap);
+            const scrubbedBody = await scrubPayload(tableName, req.body);
+            const airtableFields = mapInternalToAirtable(scrubbedBody, fieldMap);
 
             const createdRecord = await base(tableName).create([{ fields: airtableFields }]);
             const record = Array.isArray(createdRecord) ? createdRecord[0] : createdRecord;

--- a/api/threads-id.ts
+++ b/api/threads-id.ts
@@ -2,6 +2,7 @@ import getAirtableContext from "./airtable_base.js";
 import { getFieldMap } from "./resolveFieldMap.js";
 import { mapInternalToAirtable } from "./mapRecordFields.js";
 import { resolveLinkedRecordIds } from "./resolveLinkedRecordIds.js";
+import { scrubPayload } from "./scrubPayload.js";
 
 const idThreadsHandler = async (req: any, res: any) => {
     const { base, TABLES, airtableToken, baseId } = getAirtableContext();
@@ -51,7 +52,8 @@ const idThreadsHandler = async (req: any, res: any) => {
         if (req.method === "PATCH") {
             const fieldMap = getFieldMap(TABLES.THREADS);
             const resolvedBody = await resolveLinkedRecordIds(TABLES.THREADS, req.body);
-            const airtableFields = mapInternalToAirtable(resolvedBody, fieldMap);
+            const scrubbedBody = await scrubPayload(TABLES.THREADS, resolvedBody);
+            const airtableFields = mapInternalToAirtable(scrubbedBody, fieldMap);
 
             const response = await fetch(recordUrl, {
                 method: "PATCH",

--- a/api/threads-index.ts
+++ b/api/threads-index.ts
@@ -2,6 +2,7 @@ import getAirtableContext from "./airtable_base.js";
 import { getFieldMap, filterMappedFields } from "./resolveFieldMap.js";
 import { FieldSet, Record as AirtableRecord } from "airtable";
 import { resolveLinkedRecordIds } from "./resolveLinkedRecordIds.js";
+import { scrubPayload } from "./scrubPayload.js";
 
 
 const apiThreadsHandler = async (req: any, res: any) => {
@@ -42,9 +43,10 @@ const apiThreadsHandler = async (req: any, res: any) => {
         if (req.method === "POST") {
             const fieldMap = getFieldMap(tableName);
             const resolvedBody = await resolveLinkedRecordIds(tableName, req.body);
+            const scrubbedBody = await scrubPayload(tableName, resolvedBody);
 
             const createdRecord = await base(tableName).create([
-                { fields: filterMappedFields({ fields: resolvedBody }, fieldMap) }
+                { fields: filterMappedFields({ fields: scrubbedBody }, fieldMap) }
             ]);
 
             return res.status(201).json(createdRecord);

--- a/api/threads-link.ts
+++ b/api/threads-link.ts
@@ -2,6 +2,7 @@ import getAirtableContext from "./airtable_base.js";
 import { getFieldMap } from "./resolveFieldMap.js";
 import { mapInternalToAirtable } from "./mapRecordFields.js";
 import { resolveRecordId } from "./resolveLinkedRecordIds.js";
+import { scrubPayload } from "./scrubPayload.js";
 
 const threadsLinkHandler = async (req: any, res: any) => {
   const { baseId, airtableToken, TABLES } = getAirtableContext();
@@ -28,9 +29,10 @@ const threadsLinkHandler = async (req: any, res: any) => {
     const updateData = linkType === "parent"
       ? { parentThread: [parentId] }
       : { subthread: [childId] };
+    const scrubbedData = await scrubPayload(tableName, updateData);
 
     const fieldMap = getFieldMap(tableName);
-    const airtableFields = mapInternalToAirtable(updateData, fieldMap);
+    const airtableFields = mapInternalToAirtable(scrubbedData, fieldMap);
     const recordUrl = `https://api.airtable.com/v0/${baseId}/${encodeURIComponent(tableName)}/${recordId}`;
     const headers = {
       Authorization: `Bearer ${airtableToken}`,


### PR DESCRIPTION
## Summary
- add reusable `scrubPayload` helper that filters out read-only fields using latest schemas
- scrub outgoing payloads for all create/update endpoints to prevent writes to computed fields
- add unit test for payload scrubbing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6a8b0c1b48329b37fe0849842385e