### PR TITLE
Ensure payload scrub before Airtable writes

### DIFF
--- a/api/contacts-id.ts
+++ b/api/contacts-id.ts
@@ -1,8 +1,5 @@
 import getAirtableContext from "./airtable_base.js";
-import { getFieldMap } from "./resolveFieldMap.js";
-import { mapInternalToAirtable } from "./mapRecordFields.js";
-import { resolveLinkedRecordIds } from "./resolveLinkedRecordIds.js";
-import { scrubPayload } from "./scrubPayload.js";
+import { prepareFields } from "./preparePayload.js";
 
 const idContactsHandler = async (req: any, res: any) => {
   const { base, TABLES, airtableToken, baseId } = getAirtableContext();
@@ -40,10 +37,7 @@ const idContactsHandler = async (req: any, res: any) => {
     }
 
     if (req.method === "PATCH") {
-      const fieldMap = getFieldMap(TABLES.CONTACTS);
-      const resolvedBody = await resolveLinkedRecordIds(TABLES.CONTACTS, req.body);
-      const scrubbedBody = await scrubPayload(TABLES.CONTACTS, resolvedBody);
-      const airtableFields = mapInternalToAirtable(scrubbedBody, fieldMap);
+      const airtableFields = await prepareFields(TABLES.CONTACTS, req.body);
 
       const response = await fetch(recordUrl, {
         method: "PATCH",

--- a/api/log-entries-id.ts
+++ b/api/log-entries-id.ts
@@ -1,8 +1,5 @@
 import getAirtableContext from "./airtable_base.js";
-import { getFieldMap } from "./resolveFieldMap.js";
-import { mapInternalToAirtable } from "./mapRecordFields.js";
-import { resolveLinkedRecordIds } from "./resolveLinkedRecordIds.js";
-import { scrubPayload } from "./scrubPayload.js";
+import { prepareFields } from "./preparePayload.js";
 
 const idLogEntryHandler = async (req: any, res: any) => {
   const { base, TABLES, airtableToken, baseId } = getAirtableContext();
@@ -39,10 +36,7 @@ const idLogEntryHandler = async (req: any, res: any) => {
     }
 
     if (req.method === "PATCH") {
-      const fieldMap = getFieldMap(TABLES.LOGS);
-      const resolvedBody = await resolveLinkedRecordIds(TABLES.LOGS, req.body);
-      const scrubbedBody = await scrubPayload(TABLES.LOGS, resolvedBody);
-      const airtableFields = mapInternalToAirtable(scrubbedBody, fieldMap);
+      const airtableFields = await prepareFields(TABLES.LOGS, req.body);
 
       const response = await fetch(recordUrl, {
         method: "PATCH",

--- a/api/log-entries-index.ts
+++ b/api/log-entries-index.ts
@@ -1,9 +1,7 @@
 import getAirtableContext from "./airtable_base.js";
 import { getFieldMap } from "./resolveFieldMap.js";
-import { mapInternalToAirtable } from "./mapRecordFields.js";
-import { resolveLinkedRecordIds } from "./resolveLinkedRecordIds.js";
 import { airtableSearch } from "./airtableSearch.js";
-import { scrubPayload } from "./scrubPayload.js";
+import { prepareFields } from "./preparePayload.js";
 
 const apiLogEntriesHandler = async (req: any, res: any) => {
   const { base, TABLES, airtableToken, baseId } = getAirtableContext();
@@ -56,10 +54,7 @@ const apiLogEntriesHandler = async (req: any, res: any) => {
     }
 
     if (req.method === "POST") {
-      const fieldMap = getFieldMap(tableName);
-      const resolvedBody = await resolveLinkedRecordIds(tableName, req.body);
-      const scrubbedBody = await scrubPayload(tableName, resolvedBody);
-      const airtableFields = mapInternalToAirtable(scrubbedBody, fieldMap);
+      const airtableFields = await prepareFields(tableName, req.body);
 
       const [createdRecord] = await base(tableName).create([
         { fields: airtableFields },

--- a/api/preparePayload.ts
+++ b/api/preparePayload.ts
@@ -1,0 +1,11 @@
+import { getFieldMap } from "./resolveFieldMap.js";
+import { mapInternalToAirtable } from "./mapRecordFields.js";
+import { resolveLinkedRecordIds } from "./resolveLinkedRecordIds.js";
+import { scrubPayload } from "./scrubPayload.js";
+
+export async function prepareFields(tableName: string, data: Record<string, any>) {
+  const resolved = await resolveLinkedRecordIds(tableName, data);
+  const scrubbed = await scrubPayload(tableName, resolved);
+  const fieldMap = getFieldMap(tableName);
+  return mapInternalToAirtable(scrubbed, fieldMap);
+}

--- a/api/scrubPayload.ts
+++ b/api/scrubPayload.ts
@@ -35,10 +35,16 @@ async function getWritableFields(entity: string): Promise<Set<string>> {
 export async function scrubPayload(entity: string, payload: Record<string, any>): Promise<Record<string, any>> {
   const writable = await getWritableFields(entity);
   const clean: Record<string, any> = {};
+  const stripped: string[] = [];
   for (const [key, value] of Object.entries(payload || {})) {
     if (writable.has(key)) {
       clean[key] = value;
+    } else {
+      stripped.push(key);
     }
+  }
+  if (stripped.length > 0) {
+    console.log(`[scrubPayload] stripped fields for ${entity}:`, stripped);
   }
   return clean;
 }

--- a/api/snapshots-id.ts
+++ b/api/snapshots-id.ts
@@ -1,7 +1,5 @@
 import getAirtableContext from "./airtable_base.js";
-import { getFieldMap } from "./resolveFieldMap.js";
-import { mapInternalToAirtable } from "./mapRecordFields.js";
-import { scrubPayload } from "./scrubPayload.js";
+import { prepareFields } from "./preparePayload.js";
 
 const idSnapshotsHandler = async (req: any, res: any) => {
     const { base, TABLES, airtableToken, baseId } = getAirtableContext();
@@ -38,9 +36,7 @@ const idSnapshotsHandler = async (req: any, res: any) => {
         }
 
         if (req.method === "PATCH") {
-            const fieldMap = getFieldMap(TABLES.SNAPSHOTS);
-            const scrubbedBody = await scrubPayload(TABLES.SNAPSHOTS, req.body);
-            const airtableFields = mapInternalToAirtable(scrubbedBody, fieldMap);
+            const airtableFields = await prepareFields(TABLES.SNAPSHOTS, req.body);
 
             const response = await fetch(recordUrl, {
                 method: "PATCH",

--- a/api/snapshots-index.ts
+++ b/api/snapshots-index.ts
@@ -1,8 +1,7 @@
 import getAirtableContext from "./airtable_base.js";
 import { getFieldMap } from "./resolveFieldMap.js";
-import { mapInternalToAirtable } from "./mapRecordFields.js";
 import { FieldSet, Record as AirtableRecord } from "airtable";
-import { scrubPayload } from "./scrubPayload.js";
+import { prepareFields } from "./preparePayload.js";
 
 
 const apiSnapshotsHandler = async (req: any, res: any) => {
@@ -41,9 +40,7 @@ const apiSnapshotsHandler = async (req: any, res: any) => {
         }
 
         if (req.method === "POST") {
-            const fieldMap = getFieldMap(tableName);
-            const scrubbedBody = await scrubPayload(tableName, req.body);
-            const airtableFields = mapInternalToAirtable(scrubbedBody, fieldMap);
+            const airtableFields = await prepareFields(tableName, req.body);
 
             const createdRecord = await base(tableName).create([{ fields: airtableFields }]);
             const record = Array.isArray(createdRecord) ? createdRecord[0] : createdRecord;

--- a/api/threads-id.ts
+++ b/api/threads-id.ts
@@ -1,8 +1,5 @@
 import getAirtableContext from "./airtable_base.js";
-import { getFieldMap } from "./resolveFieldMap.js";
-import { mapInternalToAirtable } from "./mapRecordFields.js";
-import { resolveLinkedRecordIds } from "./resolveLinkedRecordIds.js";
-import { scrubPayload } from "./scrubPayload.js";
+import { prepareFields } from "./preparePayload.js";
 
 const idThreadsHandler = async (req: any, res: any) => {
     const { base, TABLES, airtableToken, baseId } = getAirtableContext();
@@ -50,10 +47,7 @@ const idThreadsHandler = async (req: any, res: any) => {
         }
 
         if (req.method === "PATCH") {
-            const fieldMap = getFieldMap(TABLES.THREADS);
-            const resolvedBody = await resolveLinkedRecordIds(TABLES.THREADS, req.body);
-            const scrubbedBody = await scrubPayload(TABLES.THREADS, resolvedBody);
-            const airtableFields = mapInternalToAirtable(scrubbedBody, fieldMap);
+            const airtableFields = await prepareFields(TABLES.THREADS, req.body);
 
             const response = await fetch(recordUrl, {
                 method: "PATCH",

--- a/api/threads-index.ts
+++ b/api/threads-index.ts
@@ -1,8 +1,7 @@
 import getAirtableContext from "./airtable_base.js";
-import { getFieldMap, filterMappedFields } from "./resolveFieldMap.js";
+import { getFieldMap } from "./resolveFieldMap.js";
 import { FieldSet, Record as AirtableRecord } from "airtable";
-import { resolveLinkedRecordIds } from "./resolveLinkedRecordIds.js";
-import { scrubPayload } from "./scrubPayload.js";
+import { prepareFields } from "./preparePayload.js";
 
 
 const apiThreadsHandler = async (req: any, res: any) => {
@@ -41,12 +40,10 @@ const apiThreadsHandler = async (req: any, res: any) => {
         }
 
         if (req.method === "POST") {
-            const fieldMap = getFieldMap(tableName);
-            const resolvedBody = await resolveLinkedRecordIds(tableName, req.body);
-            const scrubbedBody = await scrubPayload(tableName, resolvedBody);
+            const airtableFields = await prepareFields(tableName, req.body);
 
             const createdRecord = await base(tableName).create([
-                { fields: filterMappedFields({ fields: scrubbedBody }, fieldMap) }
+                { fields: airtableFields }
             ]);
 
             return res.status(201).json(createdRecord);

--- a/api/threads-link.ts
+++ b/api/threads-link.ts
@@ -1,8 +1,6 @@
 import getAirtableContext from "./airtable_base.js";
-import { getFieldMap } from "./resolveFieldMap.js";
-import { mapInternalToAirtable } from "./mapRecordFields.js";
 import { resolveRecordId } from "./resolveLinkedRecordIds.js";
-import { scrubPayload } from "./scrubPayload.js";
+import { prepareFields } from "./preparePayload.js";
 
 const threadsLinkHandler = async (req: any, res: any) => {
   const { baseId, airtableToken, TABLES } = getAirtableContext();
@@ -29,10 +27,7 @@ const threadsLinkHandler = async (req: any, res: any) => {
     const updateData = linkType === "parent"
       ? { parentThread: [parentId] }
       : { subthread: [childId] };
-    const scrubbedData = await scrubPayload(tableName, updateData);
-
-    const fieldMap = getFieldMap(tableName);
-    const airtableFields = mapInternalToAirtable(scrubbedData, fieldMap);
+    const airtableFields = await prepareFields(tableName, updateData);
     const recordUrl = `https://api.airtable.com/v0/${baseId}/${encodeURIComponent(tableName)}/${recordId}`;
     const headers = {
       Authorization: `Bearer ${airtableToken}`,


### PR DESCRIPTION
## Summary
- centralize linked-record resolution and schema-based scrubbing in `prepareFields`
- log stripped fields during scrub
- route all POST/PATCH handlers through new scrub helper

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c4ac10a0832996399b66d740553c