### PR TITLE
feat: relax scrubPayload and log stripped fields

### DIFF
--- a/__tests__/scrubPayload.test.ts
+++ b/__tests__/scrubPayload.test.ts
@@ -9,7 +9,13 @@ describe("scrubPayload", () => {
       lastModified: "2024-02-01",
       extra: "ignore",
     };
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
     const cleaned = await scrubPayload("Contacts", payload);
     expect(cleaned).toEqual({ name: "Alice" });
+    expect(logSpy).toHaveBeenCalledWith(
+      "[scrubPayload] stripped fields for contacts:",
+      ["id", "created", "lastModified", "extra"],
+    );
+    logSpy.mockRestore();
   });
 });

--- a/api/scrubPayload.ts
+++ b/api/scrubPayload.ts
@@ -44,7 +44,7 @@ export async function scrubPayload(entity: string, payload: Record<string, any>)
     }
   }
   if (stripped.length > 0) {
-    console.log(`[scrubPayload] stripped fields for ${entity}:`, stripped);
+    console.log(`[scrubPayload] stripped fields for ${entity.toLowerCase()}:`, stripped);
   }
   return clean;
 }


### PR DESCRIPTION
## Summary
- log removed fields from scrubPayload using lower-case entity names
- test that scrubPayload logs stripped fields while returning a clean payload

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6d3a647ec832980102afe9f773bac