### PR TITLE
Deduplicate Framer inquiries logging

### DIFF
--- a/api/inquiries.ts
+++ b/api/inquiries.ts
@@ -182,6 +182,30 @@ const inquiriesHandler = async (req: any, res: any) => {
     const contactFieldMap = getFieldMap(contactsTable);
     const logFieldMap = getFieldMap(logsTable);
 
+    const logIdFieldName = logFieldMap.logId || "Log ID";
+    const escapedSubmissionId = submissionId.replace(/"/g, '\\"');
+
+    const { records: existingLogs } = await airtableSearch(
+      logsTable,
+      `{${logIdFieldName}} = "${escapedSubmissionId}"`,
+      { maxRecords: 1 },
+    );
+
+    if (existingLogs && existingLogs.length > 0) {
+      const existingLog = existingLogs[0];
+      const linkedContactsFieldName = logFieldMap.linkedContacts || "Linked Contacts";
+      const linkedContacts = existingLog.fields?.[linkedContactsFieldName];
+
+      return res.status(200).json({
+        status: "success",
+        contactId:
+          Array.isArray(linkedContacts) && linkedContacts.length > 0
+            ? linkedContacts[0]
+            : undefined,
+        logId: existingLog.id,
+      });
+    }
+
     const emailFieldName = contactFieldMap.email || "Email";
     const normalizedEmail = email.trim().toLowerCase();
     const escapedEmail = normalizedEmail.replace(/"/g, '\\"');
@@ -222,6 +246,7 @@ const inquiriesHandler = async (req: any, res: any) => {
       name: summaryText,
       content: message ?? "",
       logType: "Inquiry",
+      logId: submissionId,
       linkedContacts: [contactId],
       linkedThreads: [inboundThreadId],
       date: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- add guard in inquiries handler to return existing log when the submission ID already exists in Airtable
- store the Framer submission ID on new log entries to support idempotent processing

## Testing
- npm test -- --runInBand


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c5be069c48329b7ab0e9076549665)